### PR TITLE
Replace dependency on constraint with a local copy of package

### DIFF
--- a/channels/channel.go
+++ b/channels/channel.go
@@ -1,7 +1,7 @@
 package channels
 
 import (
-	"constraints"
+	"github.com/life4/genesis/constraints"
 	"sync"
 )
 

--- a/channels/sequence.go
+++ b/channels/sequence.go
@@ -1,7 +1,7 @@
 package channels
 
 import (
-	"constraints"
+	"github.com/life4/genesis/constraints"
 	"context"
 )
 

--- a/constraints/constraints.go
+++ b/constraints/constraints.go
@@ -1,0 +1,50 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package constraints defines a set of useful constraints to be used
+// with type parameters.
+package constraints
+
+// Signed is a constraint that permits any signed integer type.
+// If future releases of Go add new predeclared signed integer types,
+// this constraint will be modified to include them.
+type Signed interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64
+}
+
+// Unsigned is a constraint that permits any unsigned integer type.
+// If future releases of Go add new predeclared unsigned integer types,
+// this constraint will be modified to include them.
+type Unsigned interface {
+	~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+// Integer is a constraint that permits any integer type.
+// If future releases of Go add new predeclared integer types,
+// this constraint will be modified to include them.
+type Integer interface {
+	Signed | Unsigned
+}
+
+// Float is a constraint that permits any floating-point type.
+// If future releases of Go add new predeclared floating-point types,
+// this constraint will be modified to include them.
+type Float interface {
+	~float32 | ~float64
+}
+
+// Complex is a constraint that permits any complex numeric type.
+// If future releases of Go add new predeclared complex numeric types,
+// this constraint will be modified to include them.
+type Complex interface {
+	~complex64 | ~complex128
+}
+
+// Ordered is a constraint that permits any ordered type: any type
+// that supports the operators < <= >= >.
+// If future releases of Go add new ordered types,
+// this constraint will be modified to include them.
+type Ordered interface {
+	Integer | Float | ~string
+}

--- a/constraints/constraints.go
+++ b/constraints/constraints.go
@@ -34,13 +34,6 @@ type Float interface {
 	~float32 | ~float64
 }
 
-// Complex is a constraint that permits any complex numeric type.
-// If future releases of Go add new predeclared complex numeric types,
-// this constraint will be modified to include them.
-type Complex interface {
-	~complex64 | ~complex128
-}
-
 // Ordered is a constraint that permits any ordered type: any type
 // that supports the operators < <= >= >.
 // If future releases of Go add new ordered types,

--- a/lambdas/checks.go
+++ b/lambdas/checks.go
@@ -1,6 +1,6 @@
 package lambdas
 
-import "constraints"
+import "github.com/life4/genesis/constraints"
 
 // EqualTo returns lambda that checks if an item is equal to the given value.
 func EqualTo[T comparable](a T) func(T) bool {

--- a/lambdas/glambda.go
+++ b/lambdas/glambda.go
@@ -1,6 +1,6 @@
 package lambdas
 
-import "constraints"
+import "github.com/life4/genesis/constraints"
 
 type Number interface {
 	constraints.Integer | constraints.Float

--- a/slices/slice.go
+++ b/slices/slice.go
@@ -1,7 +1,7 @@
 package slices
 
 import (
-	"constraints"
+	"github.com/life4/genesis/constraints"
 	"fmt"
 	"math/rand"
 	"sort"

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -1,7 +1,7 @@
 package slices
 
 import (
-	"constraints"
+	"github.com/life4/genesis/constraints"
 )
 
 // Any returns true if f returns true for any element in arr


### PR DESCRIPTION
Fixes the constraint issue in Go 1.18 and lets us use the great library 🔥.