### PR TITLE
Channels: improved cancellation and channel buffering

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,8 +2,13 @@
 version: "3"
 
 tasks:
+  test:
+    desc: Run go tests with coverage and timeout and without cache
+    cmds:
+      - go test -count 1 -cover -timeout 1s ./...
+
   release:
-    desc: "Tag and upload release"
+    desc: Tag and upload release
     cmds:
       - which gh
       - test v{{.CLI_ARGS}}

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -1,11 +1,12 @@
 package channels
 
 import (
-	"github.com/life4/genesis/constraints"
 	"sync"
+
+	"github.com/life4/genesis/constraints"
 )
 
-// Any returns true if f returns true for any element in channel
+// Any returns true if f returns true for any element in channel.
 func Any[T any](c <-chan T, f func(el T) bool) bool {
 	for el := range c {
 		if f(el) {
@@ -15,7 +16,7 @@ func Any[T any](c <-chan T, f func(el T) bool) bool {
 	return false
 }
 
-// All returns true if f returns true for all elements in channel
+// All returns true if f returns true for all elements in channel.
 func All[T any](c <-chan T, f func(el T) bool) bool {
 	for el := range c {
 		if !f(el) {
@@ -25,10 +26,15 @@ func All[T any](c <-chan T, f func(el T) bool) bool {
 	return true
 }
 
-// ChunkEvery returns channel with slices containing count elements each
+// ChunkEvery returns channel with slices containing count elements each.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
 func ChunkEvery[T any](c <-chan T, count int) chan []T {
 	chunks := make(chan []T, 1)
 	go func() {
+		defer close(chunks)
 		chunk := make([]T, 0, count)
 		i := 0
 		for el := range c {
@@ -43,7 +49,6 @@ func ChunkEvery[T any](c <-chan T, count int) chan []T {
 		if len(chunk) > 0 {
 			chunks <- chunk
 		}
-		close(chunks)
 	}()
 	return chunks
 }
@@ -61,9 +66,14 @@ func Count[T comparable](c <-chan T, el T) int {
 
 // Drop drops first n elements from channel c and returns a new channel with the rest.
 // It returns channel do be unblocking. If you want array instead, wrap result into TakeAll.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
 func Drop[T any](c <-chan T, n int) chan T {
 	result := make(chan T)
 	go func() {
+		defer close(result)
 		i := 0
 		for el := range c {
 			if i >= n {
@@ -71,12 +81,11 @@ func Drop[T any](c <-chan T, n int) chan T {
 			}
 			i++
 		}
-		close(result)
 	}()
 	return result
 }
 
-// Each calls f for every element in the channel
+// Each calls f for every element in the channel.
 func Each[T any](c <-chan T, f func(el T)) {
 	for el := range c {
 		f(el)
@@ -84,33 +93,41 @@ func Each[T any](c <-chan T, f func(el T)) {
 }
 
 // Filter returns a new channel with elements from input channel
-// for which f returns true
+// for which f returns true.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
 func Filter[T any](c <-chan T, f func(el T) bool) chan T {
 	result := make(chan T)
 	go func() {
+		defer close(result)
 		for el := range c {
 			if f(el) {
 				result <- el
 			}
 		}
-		close(result)
 	}()
 	return result
 }
 
-// Map applies f to all elements from channel and returns channel with results
+// Map applies f to all elements from channel and returns channel with results.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
 func Map[T any, G any](c <-chan T, f func(el T) G) chan G {
 	result := make(chan G, 1)
 	go func() {
+		defer close(result)
 		for el := range c {
 			result <- f(el)
 		}
-		close(result)
 	}()
 	return result
 }
 
-// Max returns the maximal element from channel
+// Max returns the maximal element from channel.
 func Max[T constraints.Ordered](c <-chan T) (T, error) {
 	max, ok := <-c
 	if !ok {
@@ -124,7 +141,7 @@ func Max[T constraints.Ordered](c <-chan T) (T, error) {
 	return max, nil
 }
 
-// Min returns the minimal element from channel
+// Min returns the minimal element from channel.
 func Min[T constraints.Ordered](c <-chan T) (T, error) {
 	min, ok := <-c
 	if !ok {
@@ -138,7 +155,7 @@ func Min[T constraints.Ordered](c <-chan T) (T, error) {
 	return min, nil
 }
 
-// Reduce applies f to acc and every element from channel and returns acc
+// Reduce applies f to acc and every element from channel and returns acc.
 func Reduce[T any, G any](c <-chan T, acc G, f func(el T, acc G) G) G {
 	for el := range c {
 		acc = f(el, acc)
@@ -146,20 +163,24 @@ func Reduce[T any, G any](c <-chan T, acc G, f func(el T, acc G) G) G {
 	return acc
 }
 
-// Scan is like Reduce, but returns slice of f results
+// Scan is like Reduce, but returns slice of f results.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
 func Scan[T any, G any](c <-chan T, acc G, f func(el T, acc G) G) chan G {
 	result := make(chan G, 1)
 	go func() {
+		defer close(result)
 		for el := range c {
 			acc = f(el, acc)
 			result <- acc
 		}
-		close(result)
 	}()
 	return result
 }
 
-// Sum returns sum of all elements from channel
+// Sum returns sum of all elements from channel.
 func Sum[T constraints.Ordered](c <-chan T) T {
 	var sum T
 	for el := range c {
@@ -169,6 +190,10 @@ func Sum[T constraints.Ordered](c <-chan T) T {
 }
 
 // Take takes first count elements from the channel.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
 func Take[T any](c <-chan T, count int) chan T {
 	result := make(chan T)
 	go func() {
@@ -188,13 +213,23 @@ func Take[T any](c <-chan T, count int) chan T {
 	return result
 }
 
-// Tee returns "count" number of channels with elements from the input channel
+// Tee returns "count" number of channels with elements from the input channel.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channels are closed when this goroutine finishes.
 func Tee[T any](c <-chan T, count int) []chan T {
 	channels := make([]chan T, 0, count)
 	for i := 0; i < count; i++ {
 		channels = append(channels, make(chan T))
 	}
 	go func() {
+		defer func() {
+			for _, ch := range channels {
+				close(ch)
+			}
+		}()
+
 		for el := range c {
 			wg := sync.WaitGroup{}
 			putInto := func(ch chan T) {
@@ -206,9 +241,6 @@ func Tee[T any](c <-chan T, count int) []chan T {
 				putInto(ch)
 			}
 			wg.Wait()
-		}
-		for _, ch := range channels {
-			close(ch)
 		}
 	}()
 	return channels

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -31,6 +31,11 @@ func All[T any](c <-chan T, f func(el T) bool) bool {
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the input channel is closed.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
 func ChunkEvery[T any](c <-chan T, count int) chan []T {
 	chunks := make(chan []T, 1)
 	go func() {
@@ -70,6 +75,11 @@ func Count[T comparable](c <-chan T, el T) int {
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the input channel is closed.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
 func Drop[T any](c <-chan T, n int) chan T {
 	result := make(chan T)
 	go func() {
@@ -98,6 +108,11 @@ func Each[T any](c <-chan T, f func(el T)) {
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the input channel is closed.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
 func Filter[T any](c <-chan T, f func(el T) bool) chan T {
 	result := make(chan T)
 	go func() {
@@ -116,6 +131,11 @@ func Filter[T any](c <-chan T, f func(el T) bool) chan T {
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the input channel is closed.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
 func Map[T any, G any](c <-chan T, f func(el T) G) chan G {
 	result := make(chan G, 1)
 	go func() {
@@ -168,6 +188,11 @@ func Reduce[T any, G any](c <-chan T, acc G, f func(el T, acc G) G) G {
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the input channel is closed.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
 func Scan[T any, G any](c <-chan T, acc G, f func(el T, acc G) G) chan G {
 	result := make(chan G, 1)
 	go func() {
@@ -194,6 +219,11 @@ func Sum[T constraints.Ordered](c <-chan T) T {
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the input channel is closed.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
 func Take[T any](c <-chan T, count int) chan T {
 	result := make(chan T)
 	go func() {
@@ -218,6 +248,11 @@ func Take[T any](c <-chan T, count int) chan T {
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the input channel is closed.
 // The returned channels are closed when this goroutine finishes.
+//
+// ⏸️ The returned channels are unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from all the output channels
+// is consumed by another goroutine(s).
 func Tee[T any](c <-chan T, count int) []chan T {
 	channels := make([]chan T, 0, count)
 	for i := 0; i < count; i++ {
@@ -238,7 +273,7 @@ func Tee[T any](c <-chan T, count int) []chan T {
 			}
 			wg.Add(count)
 			for _, ch := range channels {
-				putInto(ch)
+				go putInto(ch)
 			}
 			wg.Wait()
 		}

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -291,6 +291,26 @@ func ToSlice[T any](c <-chan T) []T {
 	return result
 }
 
+// WithBuffer creates an echo channel of the given one with the given buffer size.
+//
+// This function effectively makes writes into the given channel non-blocking
+// until the buffer size of pending messages is reached, assuming that all reads
+// will be done only from the channel that the function returns.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
+func WithBuffer[T any](c <-chan T, bufSize int) chan T {
+	result := make(chan T, bufSize)
+	go func() {
+		defer close(result)
+		for el := range c {
+			result <- el
+		}
+	}()
+	return result
+}
+
 // WithContext creates an echo channel of the given one that can be cancelled with ctx.
 //
 // ⏹️ Internally, the function starts a goroutine

--- a/channels/channel_test.go
+++ b/channels/channel_test.go
@@ -429,3 +429,13 @@ func TestWithContext_Cancellation(t *testing.T) {
 	is.Equal(r, []int{11, 12})
 	close(c1)
 }
+
+func TestWithContext_CancelWaitingInput(t *testing.T) {
+	is := is.New(t)
+	c1 := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	c2 := channels.WithContext(c1, ctx)
+	cancel()
+	_, more := <-c2
+	is.True(!more)
+}

--- a/channels/doc.go
+++ b/channels/doc.go
@@ -2,6 +2,14 @@
 //
 // The symbol ⏹️ indicates paragraph describing cancellation
 // of goroutines and channels that the function creates.
+// Most of the functions in the package are cancelled
+// when the passed in channel is closed.
+// If you want to cancel them using a Context instead,
+// wrap the passed in channel into [WithContext].
 //
 // The symbol ⏸️ indicates a notice about unbuffered channels.
+// All functions in the package return unbuffered channels,
+// regardless of if the input channel is buffered or not.
+// If you want to make the returned channel buffered,
+// wrap it into [WithBuffer].
 package channels

--- a/channels/doc.go
+++ b/channels/doc.go
@@ -1,2 +1,7 @@
 // Package channels provides generic functions for channels.
+//
+// The symbol ⏹️ indicates paragraph describing cancellation
+// of goroutines and channels that the function creates.
+//
+// The symbol ⏸️ indicates a notice about unbuffered channels.
 package channels

--- a/channels/errors.go
+++ b/channels/errors.go
@@ -4,5 +4,5 @@ import (
 	"errors"
 )
 
-// ErrEmpty is an error for empty slice when it's expected to have elements
+// ErrEmpty is an error for when channel is closed without any elements being sent
 var ErrEmpty = errors.New("container is empty")

--- a/channels/sequence.go
+++ b/channels/sequence.go
@@ -11,6 +11,8 @@ import (
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the ctx is cancelled.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
 func Counter[T constraints.Integer](ctx context.Context, start T, step T) chan T {
 	c := make(chan T)
 	go func() {
@@ -33,6 +35,8 @@ func Counter[T constraints.Integer](ctx context.Context, start T, step T) chan T
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the ctx is cancelled.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
 func Exponential[T constraints.Integer](ctx context.Context, start T, factor T) chan T {
 	c := make(chan T)
 	go func() {
@@ -54,6 +58,8 @@ func Exponential[T constraints.Integer](ctx context.Context, start T, factor T) 
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the ctx is cancelled.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
 func Iterate[T constraints.Integer](ctx context.Context, val T, f func(val T) T) chan T {
 	c := make(chan T)
 	go func() {
@@ -75,6 +81,8 @@ func Iterate[T constraints.Integer](ctx context.Context, val T, f func(val T) T)
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the ctx is cancelled.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
 func Range[T constraints.Integer](ctx context.Context, start T, end T, step T) chan T {
 	c := make(chan T)
 	pos := start <= end
@@ -93,6 +101,8 @@ func Range[T constraints.Integer](ctx context.Context, start T, end T, step T) c
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the ctx is cancelled.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
 func Repeat[T constraints.Integer](ctx context.Context, val T) chan T {
 	c := make(chan T)
 	go func() {
@@ -114,6 +124,8 @@ func Repeat[T constraints.Integer](ctx context.Context, val T) chan T {
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the ctx is cancelled.
 // The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
 func Replicate[T constraints.Integer](ctx context.Context, val T, n int) chan T {
 	c := make(chan T)
 	go func() {

--- a/channels/sequence.go
+++ b/channels/sequence.go
@@ -1,11 +1,16 @@
 package channels
 
 import (
-	"github.com/life4/genesis/constraints"
 	"context"
+
+	"github.com/life4/genesis/constraints"
 )
 
-// Counter is like Range, but infinite
+// Counter is like Range, but infinite.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the ctx is cancelled.
+// The returned channel is closed when this goroutine finishes.
 func Counter[T constraints.Integer](ctx context.Context, start T, step T) chan T {
 	c := make(chan T)
 	go func() {
@@ -23,7 +28,11 @@ func Counter[T constraints.Integer](ctx context.Context, start T, step T) chan T
 }
 
 // Exponential generates elements from start with
-// multiplication of value on factor on every step
+// multiplication of value on factor on every step.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the ctx is cancelled.
+// The returned channel is closed when this goroutine finishes.
 func Exponential[T constraints.Integer](ctx context.Context, start T, factor T) chan T {
 	c := make(chan T)
 	go func() {
@@ -40,7 +49,11 @@ func Exponential[T constraints.Integer](ctx context.Context, start T, factor T) 
 	return c
 }
 
-// Iterate returns an infinite list of repeated applications of f to val
+// Iterate returns an infinite list of repeated applications of f to val.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the ctx is cancelled.
+// The returned channel is closed when this goroutine finishes.
 func Iterate[T constraints.Integer](ctx context.Context, val T, f func(val T) T) chan T {
 	c := make(chan T)
 	go func() {
@@ -57,21 +70,29 @@ func Iterate[T constraints.Integer](ctx context.Context, val T, f func(val T) T)
 	return c
 }
 
-// Range generates elements from start to end with given step
+// Range generates elements from start to end with given step.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the ctx is cancelled.
+// The returned channel is closed when this goroutine finishes.
 func Range[T constraints.Integer](ctx context.Context, start T, end T, step T) chan T {
 	c := make(chan T)
 	pos := start <= end
 	go func() {
+		defer close(c)
 		for pos && (start < end) || !pos && (start > end) {
 			c <- start
 			start += step
 		}
-		close(c)
 	}()
 	return c
 }
 
-// Repeat returns channel that produces val infinite times
+// Repeat returns channel that produces val infinite times.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the ctx is cancelled.
+// The returned channel is closed when this goroutine finishes.
 func Repeat[T constraints.Integer](ctx context.Context, val T) chan T {
 	c := make(chan T)
 	go func() {
@@ -88,14 +109,18 @@ func Repeat[T constraints.Integer](ctx context.Context, val T) chan T {
 	return c
 }
 
-// Replicate returns channel that produces val n times
+// Replicate returns channel that produces val n times.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the ctx is cancelled.
+// The returned channel is closed when this goroutine finishes.
 func Replicate[T constraints.Integer](ctx context.Context, val T, n int) chan T {
 	c := make(chan T)
 	go func() {
+		defer close(c)
 		for i := 0; i < n; i++ {
 			c <- val
 		}
-		close(c)
 	}()
 	return c
 }


### PR DESCRIPTION
For `channels` package:

1. Document how to cancel each of the functions.
2. Add a note on using unbuffered channels.
3. Add `WithContext` to allow canceling functions without closing the input channel and using a context instead.
4. Add `WithBuffering` to make any channel buffered.
