### PR TITLE
Lots of new functions for channels

### DIFF
--- a/channels/channel.go
+++ b/channels/channel.go
@@ -180,7 +180,12 @@ func Filter[T any](c <-chan T, f func(el T) bool) chan T {
 	return result
 }
 
-// First selects the first available element from the given channels.
+// First is an alias for [FirstC] without a context.
+func First[T any](cs ...<-chan T) (T, error) {
+	return FirstC(context.Background(), cs...)
+}
+
+// FirstC selects the first available element from the given channels.
 //
 // The function returns in one of the following cases:
 //
@@ -225,7 +230,7 @@ func Filter[T any](c <-chan T, f func(el T) bool) chan T {
 //
 // [starvation]: https://en.wikipedia.org/wiki/Starvation_(computer_science)
 // [Go specification]: https://go.dev/ref/spec#Select_statements
-func First[T any](ctx context.Context, cs ...<-chan T) (T, error) {
+func FirstC[T any](ctx context.Context, cs ...<-chan T) (T, error) {
 	// try to use a regular select if a small number of channels is passed
 	switch len(cs) {
 	case 0:

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -363,7 +363,12 @@ func Max[T constraints.Ordered](c <-chan T) (T, error) {
 	return max, nil
 }
 
-// Merge multiple channels into one.
+// Merge is an alias for [MergeC] without a context.
+func Merge[T any](cs ...<-chan T) chan T {
+	return MergeC(context.Background(), cs...)
+}
+
+// MergeC merges multiple channels into one.
 //
 // The order in which elements are merged from different channels
 // is not guaranteed.
@@ -377,7 +382,7 @@ func Max[T constraints.Ordered](c <-chan T) (T, error) {
 // The goroutines will be blocked and won't consume elements
 // from the input channels until the value from the output channel
 // is consumed by another goroutine.
-func Merge[T any](ctx context.Context, cs ...<-chan T) chan T {
+func MergeC[T any](ctx context.Context, cs ...<-chan T) chan T {
 	res := make(chan T)
 
 	// make sure the result channel is closed

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -614,7 +614,7 @@ func ToSlice[T any](c <-chan T) []T {
 //
 // ⏹️ Internally, the function starts a goroutine.
 // This goroutine finishes when the input channel is closed.
-// The returned channels are closed when this goroutine finishes.
+// The returned channel is closed when this goroutine finishes.
 //
 // 🐞 BUG: The goroutine might not be cleaned up if
 // the input channel is closed but the goroutine is blocked
@@ -623,10 +623,6 @@ func ToSlice[T any](c <-chan T) []T {
 // from the output channel (or at least up to the buffer size).
 // In a future release, the function
 // might be changed to accept a context for better cancelation.
-//
-// ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the input channel is closed.
-// The returned channel is closed when this goroutine finishes.
 func WithBuffer[T any](c <-chan T, bufSize int) chan T {
 	result := make(chan T, bufSize)
 	go func() {

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -28,6 +28,16 @@ func All[T any](c <-chan T, f func(el T) bool) bool {
 	return true
 }
 
+// BufferSize returns how many messages a channel can hold before being blocked.
+//
+// When you push that many messages in the channel, the next attempt
+// to write in it will block until another goroutine reads a message.
+//
+// For unbuffered channels the result is 0.
+func BufferSize[T any](c <-chan T) int {
+	return cap(c)
+}
+
 // ChunkEvery returns channel with slices containing count elements each.
 //
 // ⏹️ Internally, the function starts a goroutine.
@@ -232,6 +242,23 @@ func First[T any](ctx context.Context, cs ...<-chan T) (T, error) {
 		return val, ErrClosed
 	}
 	return val, nil
+}
+
+// IsEmpty returns true if there are no messages in the channel.
+//
+// For unbuffered channels, the result is always true.
+func IsEmpty[T any](c <-chan T) bool {
+	return len(c) == 0
+}
+
+// IsFull returns true if the channel's buffer is full.
+//
+// Attempts to write into a full channel will block
+// until another goroutine reads a message from it.
+//
+// For unbuffered channels, the result is always true.
+func IsFull[T any](c <-chan T) bool {
+	return len(c) == cap(c)
 }
 
 // Map applies f to all elements from channel and returns channel with results.

--- a/channels/channel_test.go
+++ b/channels/channel_test.go
@@ -199,6 +199,7 @@ func TestFilter(t *testing.T) {
 func TestFirst(t *testing.T) {
 	t.Parallel()
 	is := is.New(t)
+	ctx := context.Background()
 	f := func(n, i int) {
 		csW := make([]chan<- int, n)
 		csR := make([]<-chan int, n)
@@ -208,7 +209,7 @@ func TestFirst(t *testing.T) {
 			csR[i] = c
 		}
 		go func() { csW[i] <- 12 }()
-		v, err := channels.First(context.Background(), csR...)
+		v, err := channels.First(ctx, csR...)
 		is.NoErr(err)
 		is.Equal(v, 12)
 	}
@@ -218,7 +219,7 @@ func TestFirst(t *testing.T) {
 		}
 	}
 
-	_, err := channels.First[int](context.Background())
+	_, err := channels.First[int](ctx)
 	is.Equal(err, channels.ErrEmpty)
 }
 
@@ -346,7 +347,7 @@ func TestMin(t *testing.T) {
 func TestPop(t *testing.T) {
 	is := is.New(t)
 
-	// exit on cancelled context
+	// exit on canceled context
 	c := make(chan int)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -370,7 +371,7 @@ func TestPop(t *testing.T) {
 }
 
 func TestPush(t *testing.T) {
-	// exit on cancelled context
+	// exit on canceled context
 	c := make(chan int)
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/channels/channel_test.go
+++ b/channels/channel_test.go
@@ -208,7 +208,7 @@ func TestFirst(t *testing.T) {
 			csR[i] = c
 		}
 		go func() { csW[i] <- 12 }()
-		v, err := channels.First(csR...)
+		v, err := channels.First(context.Background(), csR...)
 		is.NoErr(err)
 		is.Equal(v, 12)
 	}
@@ -218,7 +218,7 @@ func TestFirst(t *testing.T) {
 		}
 	}
 
-	_, err := channels.First[int]()
+	_, err := channels.First[int](context.Background())
 	is.Equal(err, channels.ErrEmpty)
 }
 
@@ -257,7 +257,7 @@ func TestFirst_Starvation(t *testing.T) {
 	// Calculate how many messages are received from each channel.
 	nReceived := make(map[int]uint32)
 	for k := 0; k < nChannels*4; k++ {
-		i, err := channels.First(csR...)
+		i, err := channels.First(context.Background(), csR...)
 		is.NoErr(err)
 		nReceived[i] += 1
 	}

--- a/channels/channel_test.go
+++ b/channels/channel_test.go
@@ -74,6 +74,13 @@ func TestAll(t *testing.T) {
 	f([]int{2, 4, 6, 8, 11, 12}, false)
 }
 
+func TestBufferSize(t *testing.T) {
+	is := is.New(t)
+	is.Equal(channels.BufferSize(make(chan int, 3)), 3)
+	is.Equal(channels.BufferSize(make(chan int)), 0)
+	is.Equal(channels.BufferSize[int](nil), 0)
+}
+
 func TestClose(t *testing.T) {
 	is := is.New(t)
 	is.True(!channels.Close[int](nil))
@@ -272,6 +279,34 @@ func TestFirst_Starvation(t *testing.T) {
 			t.Errorf("channel %d is starved (n=%d)", i, n)
 		}
 	}
+}
+
+func TestIsEmpty(t *testing.T) {
+	is := is.New(t)
+	is.True(channels.IsEmpty(make(chan int, 3)))
+	is.True(channels.IsEmpty(make(chan int)))
+	c := make(chan int, 3)
+	is.True(channels.IsEmpty(c))
+	c <- 42
+	is.True(!channels.IsEmpty(c))
+	<-c
+	is.True(channels.IsEmpty(c))
+}
+
+func TestIsFull(t *testing.T) {
+	is := is.New(t)
+	is.True(!channels.IsFull(make(chan int, 3)))
+	is.True(channels.IsFull(make(chan int)))
+	c := make(chan int, 3)
+	is.True(!channels.IsFull(c))
+	c <- 42
+	is.True(!channels.IsFull(c))
+	c <- 43
+	is.True(!channels.IsFull(c))
+	c <- 44
+	is.True(channels.IsFull(c))
+	<-c
+	is.True(!channels.IsFull(c))
 }
 
 func TestMap(t *testing.T) {

--- a/channels/channel_test.go
+++ b/channels/channel_test.go
@@ -281,6 +281,24 @@ func TestFirst_Starvation(t *testing.T) {
 	}
 }
 
+func TestFlatten(t *testing.T) {
+	is := is.New(t)
+	chIn := make(chan (<-chan int))
+	go func() {
+		for i := 0; i < 3; i++ {
+			c := make(chan int)
+			chIn <- c
+			c <- i + 10
+			c <- i + 20
+			close(c)
+		}
+		close(chIn)
+	}()
+	chOut := channels.Flatten(chIn)
+	slOut := channels.ToSlice(chOut)
+	is.Equal(slOut, []int{10, 20, 11, 21, 12, 22})
+}
+
 func TestIsEmpty(t *testing.T) {
 	is := is.New(t)
 	is.True(channels.IsEmpty(make(chan int, 3)))

--- a/channels/channel_test.go
+++ b/channels/channel_test.go
@@ -196,6 +196,32 @@ func TestFilter(t *testing.T) {
 	f([]int{1, 2, 3, 4}, []int{2, 4})
 }
 
+func TestFirst(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+	f := func(n, i int) {
+		csW := make([]chan<- int, n)
+		csR := make([]<-chan int, n)
+		for i := 0; i < n; i++ {
+			c := make(chan int)
+			csW[i] = c
+			csR[i] = c
+		}
+		go func() { csW[i] <- 12 }()
+		v, err := channels.First(csR...)
+		is.NoErr(err)
+		is.Equal(v, 12)
+	}
+	for n := 1; n < 10; n++ {
+		for i := 0; i < n; i++ {
+			f(n, i)
+		}
+	}
+
+	_, err := channels.First[int]()
+	is.Equal(err, channels.ErrEmpty)
+}
+
 func TestMap(t *testing.T) {
 	is := is.New(t)
 	f := func(given []int, expected []int) {

--- a/channels/doc.go
+++ b/channels/doc.go
@@ -2,7 +2,7 @@
 //
 // The symbol ⏹️ indicates paragraph describing cancellation
 // of goroutines and channels that the function creates.
-// Most of the functions in the package are cancelled
+// Most of the functions in the package are canceled
 // when the passed in channel is closed.
 // If you want to cancel them using a Context instead,
 // wrap the passed in channel into [WithContext].
@@ -12,4 +12,6 @@
 // regardless of if the input channel is buffered or not.
 // If you want to make the returned channel buffered,
 // wrap it into [WithBuffer].
+//
+// The symbol 😱 indicates information about errors that the function may return.
 package channels

--- a/channels/errors.go
+++ b/channels/errors.go
@@ -6,3 +6,8 @@ import (
 
 // ErrEmpty is an error for when channel is closed without any elements being sent
 var ErrEmpty = errors.New("container is empty")
+
+// ErrEmpty is an error for when a channel is closed.
+// Currently is used only by [First] to distinguish a closed channel
+// from a zero value returned without adding a third `bool` return value.
+var ErrClosed = errors.New("channel is closed")

--- a/channels/sequence.go
+++ b/channels/sequence.go
@@ -9,7 +9,7 @@ import (
 // Counter is like Range, but infinite.
 //
 // ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is cancelled.
+// This goroutine finishes when the ctx is canceled.
 // The returned channel is closed when this goroutine finishes.
 //
 // ⏸️ The returned channel is unbuffered.
@@ -33,7 +33,7 @@ func Counter[T constraints.Integer](ctx context.Context, start T, step T) chan T
 // multiplication of value on factor on every step.
 //
 // ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is cancelled.
+// This goroutine finishes when the ctx is canceled.
 // The returned channel is closed when this goroutine finishes.
 //
 // ⏸️ The returned channel is unbuffered.
@@ -56,7 +56,7 @@ func Exponential[T constraints.Integer](ctx context.Context, start T, factor T) 
 // Iterate returns an infinite list of repeated applications of f to val.
 //
 // ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is cancelled.
+// This goroutine finishes when the ctx is canceled.
 // The returned channel is closed when this goroutine finishes.
 //
 // ⏸️ The returned channel is unbuffered.
@@ -79,7 +79,7 @@ func Iterate[T constraints.Integer](ctx context.Context, val T, f func(val T) T)
 // Range generates elements from start to end with given step.
 //
 // ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is cancelled.
+// This goroutine finishes when the ctx is canceled.
 // The returned channel is closed when this goroutine finishes.
 //
 // ⏸️ The returned channel is unbuffered.
@@ -99,7 +99,7 @@ func Range[T constraints.Integer](ctx context.Context, start T, end T, step T) c
 // Repeat returns channel that produces val infinite times.
 //
 // ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is cancelled.
+// This goroutine finishes when the ctx is canceled.
 // The returned channel is closed when this goroutine finishes.
 //
 // ⏸️ The returned channel is unbuffered.
@@ -122,7 +122,7 @@ func Repeat[T constraints.Integer](ctx context.Context, val T) chan T {
 // Replicate returns channel that produces val n times.
 //
 // ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is cancelled.
+// This goroutine finishes when the ctx is canceled.
 // The returned channel is closed when this goroutine finishes.
 //
 // ⏸️ The returned channel is unbuffered.

--- a/maps/maps_inplace_test.go
+++ b/maps/maps_inplace_test.go
@@ -10,9 +10,13 @@ import (
 
 func TestClear(t *testing.T) {
 	is := is.New(t)
-	m := map[int]int{1: 2, 3: 4}
-	maps.Clear(m)
-	is.Equal(m, map[int]int{})
+	m1 := map[int]int{1: 2, 3: 4}
+	maps.Clear(m1)
+	is.Equal(m1, map[int]int{})
+
+	// m2 := map[float64]int{math.NaN(): 1}
+	// maps.Clear(m2)
+	// is.Equal(m2, map[float64]int{})
 }
 
 func TestDrop(t *testing.T) {


### PR DESCRIPTION
Add many new functions for channels, some of which are inspired by "Concurrency in Go" book.

1. `First` to select first available message from a list of channels.
2. `Flatten` (called `Bridge` in the book) to turn channels of channels in a regular channel.
3. `Merge` to combine multiple channels together.
1. One-liners for inspecting channels: `BufferSize`, `IsOpen`, `IsClosed`
4. Small helpers, mostly for better cancellation: `Close`, `Push`, `Pop`

I also found a corner-case for cancellation that is present in most of the functions there. I added a comment for that. I'll address it in a follow-up PR.