### PR TITLE
channels: Use context in all functions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,26 @@
+linters:
+  disable:
+    - gosec
+    - noctx
+    - errorlint
+    - exhaustive
+    - scopelint
+    - rowserrcheck
+    - sqlclosecheck
+    - maligned
+    - depguard
+    - gofumpt
+  presets:
+    - bugs
+    # - comment
+    # - complexity
+    # - error
+    - format
+    - import
+    # - metalinter
+    # - module
+    - performance
+    # - sql
+    # - style
+    # - test
+    # - unused

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -2,10 +2,21 @@
 version: "3"
 
 tasks:
+  lint:
+    desc: Run Go linters
+    cmds:
+      - golangci-lint run
+
   test:
     desc: Run go tests with coverage and timeout and without cache
     cmds:
       - go test -count 1 -cover -timeout 1s ./...
+
+  all:
+    desc: Run all tests and linters
+    cmds:
+      - task: lint
+      - task: test
 
   release:
     desc: Tag and upload release

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -2,7 +2,6 @@ package channels
 
 import (
 	"context"
-	"reflect"
 	"sync"
 
 	"github.com/life4/genesis/constraints"
@@ -50,53 +49,6 @@ func BufferSize[T any](c <-chan T) int {
 
 func ChunkEvery[T any](c <-chan T, count int) chan []T {
 	return ChunkEveryC(context.Background(), c, count)
-}
-
-// ChunkEveryC returns channel with slices containing count elements each.
-//
-// ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the input channel is closed.
-// The returned channel is closed when this goroutine finishes.
-//
-// 🐞 BUG: The goroutine might not be cleaned up if
-// the input channel is closed but the goroutine is blocked
-// in attempt to write into the output channel.
-// To avoid the issue, make sure to consume all messages
-// from the output channel. In a future release, the function
-// might be changed to accept a context for better cancelation.
-//
-// ⏸️ The returned channel is unbuffered.
-// The goroutine will be blocked and won't consume elements
-// from the input channel until the value from the output channel
-// is consumed by another goroutine.
-func ChunkEveryC[T any](ctx context.Context, c <-chan T, count int) chan []T {
-	chunks := make(chan []T, 1)
-	go func() {
-		defer close(chunks)
-		chunk := make([]T, 0, count)
-		i := 0
-		for el := range WithContext(c, ctx) {
-			chunk = append(chunk, el)
-			i++
-			if i%count == 0 {
-				i = 0
-				select {
-				case chunks <- chunk:
-				case <-ctx.Done():
-					return
-				}
-				chunk = make([]T, 0, count)
-			}
-		}
-		if len(chunk) > 0 {
-			select {
-			case chunks <- chunk:
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
-	return chunks
 }
 
 // Close safely closes the given channel.
@@ -211,91 +163,6 @@ func First[T any](cs ...<-chan T) (T, error) {
 	return FirstC(context.Background(), cs...)
 }
 
-// FirstC selects the first available element from the given channels.
-//
-// The function returns in one of the following cases:
-//
-//  1. One of the given channels is closed. In this case,
-//     [ErrClosed] is returned.
-//  2. ⏹️ The ctx context is canceled. In this case,
-//     the cancelation reason is returned as an error.
-//  3. One of the given channels returns a value. In this case,
-//     the error is nil.
-//
-// If all channels are non-closed and empty and ctx is not canceled,
-// the function will block and wait for one of the above to occur.
-//
-// If multiple messages are received at the same time,
-// only one is chosen via a uniform pseudo-random selection (see below).
-// Other messages will stay in their queues untocuhed.
-//
-// In no scenario any messages are lost. A message is either
-// returned by a function or stays in the queue.
-//
-// # 😱 Errors
-//
-//   - [ErrEmpty]: no channels are passed into the function.
-//   - [ErrClosed]: a channel was closed.
-//   - Another: cancelation cause returned by ctx.Err().
-//
-// # 🍽 What is starvation
-//
-// Imagine that you iterate through a list of channels and return an element
-// from the first one that is available. Since the order of channels is always
-// the same, if a value is always available in a multiple channels, you'll be
-// selecting only from the first one. In other words, you never select from other
-// channels as long as the first one always has a value for you. It might result
-// in a situation when out of multiplt jobs you start only one is not blocked.
-//
-// This situation is called "[starvation]". To avoid that, the element in
-// select statement, according to the [Go specification],
-// "is chosen via a uniform pseudo-random selection".
-//
-// This function preserves that behavior by using internally
-// a dynamically created (using [reflect]) select statement.
-//
-// [starvation]: https://en.wikipedia.org/wiki/Starvation_(computer_science)
-// [Go specification]: https://go.dev/ref/spec#Select_statements
-func FirstC[T any](ctx context.Context, cs ...<-chan T) (T, error) {
-	// try to use a regular select if a small number of channels is passed
-	switch len(cs) {
-	case 0:
-		return *new(T), ErrEmpty
-	case 1:
-		select {
-		case v, ok := <-cs[0]:
-			if !ok {
-				return *new(T), ErrClosed
-			}
-			return v, nil
-		case <-ctx.Done():
-			return *new(T), ctx.Err()
-		}
-	}
-
-	cases := make([]reflect.SelectCase, 0, len(cs)+1)
-	cases = append(cases, reflect.SelectCase{
-		Dir:  reflect.SelectRecv,
-		Chan: reflect.ValueOf(ctx.Done()),
-	})
-	for _, c := range cs {
-		cases = append(cases, reflect.SelectCase{
-			Dir:  reflect.SelectRecv,
-			Chan: reflect.ValueOf(c),
-		})
-	}
-	chosen, rval, ok := reflect.Select(cases)
-	if chosen == 0 {
-		var v T
-		return v, ctx.Err()
-	}
-	val := rval.Interface().(T)
-	if !ok {
-		return val, ErrClosed
-	}
-	return val, nil
-}
-
 // Given a channel of channels of values, return a channel of values.
 //
 // This pattern is described in the "Concurrency in Go" book
@@ -399,57 +266,6 @@ func Merge[T any](cs ...<-chan T) chan T {
 	return MergeC(context.Background(), cs...)
 }
 
-// MergeC merges multiple channels into one.
-//
-// The order in which elements are merged from different channels
-// is not guaranteed.
-//
-// ⏹️ Internally, the function starts a goroutine per input channel.
-// Each of these goroutines finishes either when their input channel is closed.
-// or when the ctx context is cancelled.
-// The returned channel is closed when all of these goroutines finish.
-//
-// ⏸️ The returned channel is unbuffered.
-// The goroutines will be blocked and won't consume elements
-// from the input channels until the value from the output channel
-// is consumed by another goroutine.
-func MergeC[T any](ctx context.Context, cs ...<-chan T) chan T {
-	res := make(chan T)
-
-	// make sure the result channel is closed
-	// when all input channels are closed
-	wg := sync.WaitGroup{}
-	wg.Add(len(cs))
-	go func() {
-		wg.Wait()
-		close(res)
-	}()
-
-	echo := func(c <-chan T) {
-		wg.Done()
-		for {
-			select {
-			case v, ok := <-c:
-				if !ok {
-					return
-				}
-				select {
-				case res <- v:
-				case <-ctx.Done():
-					return
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}
-
-	for _, c := range cs {
-		go echo(c)
-	}
-	return res
-}
-
 // Min returns the minimal element from channel.
 //
 // ⏹️ The function is blocked until the channel is closed.
@@ -466,44 +282,6 @@ func Min[T constraints.Ordered](c <-chan T) (T, error) {
 		}
 	}
 	return min, nil
-}
-
-// Pop reads a value from the channel (with context).
-//
-// The function is blocking. It will wait and return
-// in one of the following conditions:
-//
-//  1. ⏹️ The context is canceled.
-//  2. ⏹️ The channel is closed.
-//  3. There is a value pushed into the channel.
-//
-// In the first two cases, the second return value (called "more" or "ok") is "false".
-// Otherwise, if a value is succesfully pulled from the channel, it is "true".
-//
-// Reads from nil channels block forever. So, if a nil channel is passed,
-// the function will exit only when the context is canceled.
-func Pop[T any](ctx context.Context, c <-chan T) (T, bool) {
-	select {
-	case v, more := <-c:
-		return v, more
-	case <-ctx.Done():
-		return *new(T), false
-	}
-}
-
-// Push writes the value into the channel (with context).
-//
-// ⚠️ Experimental! Behavior of this function might change in the future
-// or the function can be removed altogether.
-// It's not clear yet what's the best approach for when the target channel is closed.
-// By default, Go panics in this case, which might be not good in some situations.
-// Also, using this function might cause situations when the canceled context
-// will be ignored by the target function instead of exiting.
-func Push[T any](ctx context.Context, c chan<- T, v T) {
-	select {
-	case c <- v:
-	case <-ctx.Done():
-	}
 }
 
 // Reduce applies f to acc and every element from channel and returns acc.
@@ -665,48 +443,6 @@ func WithBuffer[T any](c <-chan T, bufSize int) chan T {
 		defer close(result)
 		for el := range c {
 			result <- el
-		}
-	}()
-	return result
-}
-
-// WithContext creates an echo channel of the given one that can be canceled with ctx.
-//
-// This can be useful in 2 scenarios:
-//
-//  1. To be able to cancel any function in this package
-//     without closing the original channel.
-//  2. For simpler iteration through channels with support for cancellation.
-//     This pattern is descirbed in the "Concurrency in Go" book
-//     in "The or-done-channel" chapter (page 119).
-//
-// ⏹️ Internally, the function starts a goroutine
-// that copies values from the input channel into the output one.
-// This goroutine finishes when the input channel is closed
-// or the ctx context is canceled.
-// The returned channel is closed when this goroutine finishes.
-//
-// ⏸️ The returned channel is unbuffered.
-// The goroutine will be blocked and won't consume elements
-// from the input channel until the value from the output channel
-// is consumed by another goroutine.
-func WithContext[T any](c <-chan T, ctx context.Context) chan T {
-	result := make(chan T)
-	go func() {
-		defer close(result)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case val, more := <-c:
-				if !more {
-					return
-				}
-				select {
-				case result <- val:
-				case <-ctx.Done():
-				}
-			}
 		}
 	}()
 	return result

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -7,15 +7,11 @@ import (
 )
 
 // Any returns true if f returns true for any element in channel.
-//
-// ⏹️ The function returns either when f returns true
-// or when the channel is closed. If you want to be able
-// to stop the function without closing the channel,
-// wrap the channel into [WithContext].
 func Any[T any](c <-chan T, f func(el T) bool) bool {
 	return AnyC(context.Background(), c, f)
 }
 
+// All is an alias for [AllC] without a context.
 func All[T any](c <-chan T, f func(el T) bool) bool {
 	return AllC(context.Background(), c, f)
 }
@@ -31,10 +27,6 @@ func BufferSize[T any](c <-chan T) int {
 }
 
 // ChunkEvery is an alias for [ChunkEveryC] without a context.
-//
-// ⚠️ There scenarios in which the internal goroutine that the function starts
-// is not cleaned up even after the input channel is closed.
-// To avoid the issue, use [ChunkEveryC] instead.
 func ChunkEvery[T any](c <-chan T, count int) chan []T {
 	return ChunkEveryC(context.Background(), c, count)
 }
@@ -60,25 +52,29 @@ func Close[T any](c chan<- T) bool {
 	return true
 }
 
+// Count is an alias for [CountC] without a context.
 func Count[T comparable](c <-chan T, el T) int {
 	return CountC(context.Background(), c, el)
 }
 
+// Drop is an alias for [DropC] without a context.
 func Drop[T any](c <-chan T, n int) chan T {
 	return DropC(context.Background(), c, n)
 }
 
-// Each calls f for every element in the channel.
+// Each is an alias for [EachC] without a context.
 func Each[T any](c <-chan T, f func(el T)) {
 	for el := range c {
 		f(el)
 	}
 }
 
+// Echo is an alias for [EchoC] without a context.
 func Echo[T any](from <-chan T, to chan<- T) {
 	EchoC(context.Background(), from, to)
 }
 
+// Filter is an alias for [FilterC] without a context.
 func Filter[T any](c <-chan T, f func(el T) bool) chan T {
 	return FilterC(context.Background(), c, f)
 }
@@ -88,6 +84,7 @@ func First[T any](cs ...<-chan T) (T, error) {
 	return FirstC(context.Background(), cs...)
 }
 
+// Flatten is an alias for [FlattenC] without a context.
 func Flatten[T any](c <-chan <-chan T) chan T {
 	return FlattenC(context.Background(), c)
 }
@@ -109,15 +106,12 @@ func IsFull[T any](c <-chan T) bool {
 	return len(c) == cap(c)
 }
 
+// Map is an alias for [MapC] without a context.
 func Map[T any, G any](c <-chan T, f func(el T) G) chan G {
 	return MapC(context.Background(), c, f)
 }
 
-// Max returns the maximal element from channel.
-//
-// ⏹️ The function is blocked until the channel is closed.
-//
-// 😱 If a channel is closed without any elements being emitted, `ErrEmpty` is returned.
+// Max is an alias for [MaxC] without a context.
 func Max[T constraints.Ordered](c <-chan T) (T, error) {
 	return MaxC(context.Background(), c)
 }
@@ -127,34 +121,42 @@ func Merge[T any](cs ...<-chan T) chan T {
 	return MergeC(context.Background(), cs...)
 }
 
+// Min is an alias for [MinC] without a context.
 func Min[T constraints.Ordered](c <-chan T) (T, error) {
 	return MinC(context.Background(), c)
 }
 
+// Reduce is an alias for [ReduceC] without a context.
 func Reduce[T any, G any](c <-chan T, acc G, f func(el T, acc G) G) G {
 	return ReduceC(context.Background(), c, acc, f)
 }
 
+// Scan is an alias for [ScanC] without a context.
 func Scan[T any, G any](c <-chan T, acc G, f func(el T, acc G) G) chan G {
 	return ScanC(context.Background(), c, acc, f)
 }
 
+// Sum is an alias for [SumC] without a context.
 func Sum[T constraints.Ordered](c <-chan T) T {
 	return SumC(context.Background(), c)
 }
 
+// Take is an alias for [TakeC] without a context.
 func Take[T any](c <-chan T, count int) chan T {
 	return TakeC(context.Background(), c, count)
 }
 
+// Tee is an alias for [TeeC] without a context.
 func Tee[T any](c <-chan T, count int) []chan T {
 	return TeeC(context.Background(), c, count)
 }
 
+// ToSlice is an alias for [ToSliceC] without a context.
 func ToSlice[T any](c <-chan T) []T {
 	return ToSliceC(context.Background(), c)
 }
 
+// WithBuffer is an alias for [WithBufferC] without a context.
 func WithBuffer[T any](c <-chan T, bufSize int) chan T {
 	return WithBufferC(context.Background(), c, bufSize)
 }

--- a/channels/channel.go
+++ b/channels/channel.go
@@ -75,6 +75,10 @@ func Each[T any](c <-chan T, f func(el T)) {
 	}
 }
 
+func Echo[T any](from <-chan T, to chan<- T) {
+	EchoC(context.Background(), from, to)
+}
+
 func Filter[T any](c <-chan T, f func(el T) bool) chan T {
 	return FilterC(context.Background(), c, f)
 }

--- a/channels/channel_ctx.go
+++ b/channels/channel_ctx.go
@@ -558,6 +558,224 @@ func Push[T any](ctx context.Context, c chan<- T, v T) {
 	}
 }
 
+// Reduce applies f to acc and every element from channel and returns acc.
+func ReduceC[T any, G any](ctx context.Context, c <-chan T, acc G, f func(el T, acc G) G) G {
+	for {
+		select {
+		case el, ok := <-c:
+			if !ok {
+				return acc
+			}
+			acc = f(el, acc)
+		case <-ctx.Done():
+			return acc
+		}
+	}
+}
+
+// Scan is like Reduce, but returns slice of f results.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
+//
+// 🐞 BUG: The goroutine might not be cleaned up if
+// the input channel is closed but the goroutine is blocked
+// in attempt to write into the output channel.
+// To avoid the issue, make sure to consume all messages
+// from the output channel. In a future release, the function
+// might be changed to accept a context for better cancelation.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
+func ScanC[T any, G any](ctx context.Context, c <-chan T, acc G, f func(el T, acc G) G) chan G {
+	result := make(chan G, 1)
+	go func() {
+		defer close(result)
+		for {
+			select {
+			case el, ok := <-c:
+				if !ok {
+					return
+				}
+				acc = f(el, acc)
+				select {
+				case result <- acc:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return result
+}
+
+// Sum returns sum of all elements from channel.
+func SumC[T constraints.Ordered](ctx context.Context, c <-chan T) T {
+	var sum T
+	for {
+		select {
+		case el, ok := <-c:
+			if !ok {
+				return sum
+			}
+			sum += el
+		case <-ctx.Done():
+			return sum
+		}
+	}
+}
+
+// Take takes first count elements from the channel.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
+//
+// 🐞 BUG: The goroutine might not be cleaned up if
+// the input channel is closed but the goroutine is blocked
+// in attempt to write into the output channel.
+// To avoid the issue, make sure to consume all messages
+// from the output channel. In a future release, the function
+// might be changed to accept a context for better cancelation.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
+func TakeC[T any](ctx context.Context, c <-chan T, count int) chan T {
+	result := make(chan T)
+	go func() {
+		defer close(result)
+		if count <= 0 {
+			return
+		}
+		i := 0
+		for {
+			select {
+			case el, ok := <-c:
+				if !ok {
+					return
+				}
+				select {
+				case result <- el:
+				case <-ctx.Done():
+					return
+				}
+				i++
+				if i == count {
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return result
+}
+
+// Tee returns "count" number of channels with elements from the input channel.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channels are closed when this goroutine finishes.
+//
+// 🐞 BUG: The goroutine might not be cleaned up if
+// the input channel is closed but the goroutine is blocked
+// in attempt to write into the output channel.
+// To avoid the issue, make sure to consume all messages
+// from the output channel. In a future release, the function
+// might be changed to accept a context for better cancelation.
+//
+// ⏸️ The returned channels are unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from all the output channels
+// is consumed by another goroutine(s).
+func TeeC[T any](ctx context.Context, c <-chan T, count int) []chan T {
+	channels := make([]chan T, 0, count)
+	for i := 0; i < count; i++ {
+		channels = append(channels, make(chan T))
+	}
+	go func() {
+		defer func() {
+			for _, ch := range channels {
+				close(ch)
+			}
+		}()
+
+		for {
+			select {
+			case el, ok := <-c:
+				if !ok {
+					return
+				}
+				wg := sync.WaitGroup{}
+				putInto := func(ch chan T) {
+					defer wg.Done()
+					select {
+					case ch <- el:
+					case <-ctx.Done():
+					}
+				}
+				wg.Add(count)
+				for _, ch := range channels {
+					go putInto(ch)
+				}
+				wg.Wait()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return channels
+}
+
+// ToSlice returns slice with all elements from channel.
+func ToSliceC[T any](ctx context.Context, c <-chan T) []T {
+	result := make([]T, 0)
+	for {
+		select {
+		case el, ok := <-c:
+			if !ok {
+				return result
+			}
+			result = append(result, el)
+		case <-ctx.Done():
+			return result
+		}
+	}
+}
+
+// WithBuffer creates an echo channel of the given one with the given buffer size.
+//
+// This function effectively makes writes into the given channel non-blocking
+// until the buffer size of pending messages is reached, assuming that all reads
+// will be done only from the channel that the function returns.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
+//
+// 🐞 BUG: The goroutine might not be cleaned up if
+// the input channel is closed but the goroutine is blocked
+// in attempt to write into the output channel.
+// To avoid the issue, make sure to consume all messages
+// from the output channel (or at least up to the buffer size).
+// In a future release, the function
+// might be changed to accept a context for better cancelation.
+func WithBufferC[T any](ctx context.Context, c <-chan T, bufSize int) chan T {
+	result := make(chan T, bufSize)
+	go func() {
+		defer close(result)
+		EchoC(ctx, c, result)
+	}()
+	return result
+}
+
 // WithContext creates an echo channel of the given one that can be canceled with ctx.
 //
 // This can be useful in 2 scenarios:

--- a/channels/channel_ctx.go
+++ b/channels/channel_ctx.go
@@ -1,0 +1,270 @@
+package channels
+
+import (
+	"context"
+	"reflect"
+	"sync"
+)
+
+// ChunkEveryC returns channel with slices containing count elements each.
+//
+// ⏹️ Internally, the function starts a goroutine.
+// This goroutine finishes when the input channel is closed.
+// The returned channel is closed when this goroutine finishes.
+//
+// 🐞 BUG: The goroutine might not be cleaned up if
+// the input channel is closed but the goroutine is blocked
+// in attempt to write into the output channel.
+// To avoid the issue, make sure to consume all messages
+// from the output channel. In a future release, the function
+// might be changed to accept a context for better cancelation.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
+func ChunkEveryC[T any](ctx context.Context, c <-chan T, count int) chan []T {
+	chunks := make(chan []T, 1)
+	go func() {
+		defer close(chunks)
+		chunk := make([]T, 0, count)
+		i := 0
+		for el := range WithContext(c, ctx) {
+			chunk = append(chunk, el)
+			i++
+			if i%count == 0 {
+				i = 0
+				select {
+				case chunks <- chunk:
+				case <-ctx.Done():
+					return
+				}
+				chunk = make([]T, 0, count)
+			}
+		}
+		if len(chunk) > 0 {
+			select {
+			case chunks <- chunk:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return chunks
+}
+
+// FirstC selects the first available element from the given channels.
+//
+// The function returns in one of the following cases:
+//
+//  1. One of the given channels is closed. In this case,
+//     [ErrClosed] is returned.
+//  2. ⏹️ The ctx context is canceled. In this case,
+//     the cancelation reason is returned as an error.
+//  3. One of the given channels returns a value. In this case,
+//     the error is nil.
+//
+// If all channels are non-closed and empty and ctx is not canceled,
+// the function will block and wait for one of the above to occur.
+//
+// If multiple messages are received at the same time,
+// only one is chosen via a uniform pseudo-random selection (see below).
+// Other messages will stay in their queues untocuhed.
+//
+// In no scenario any messages are lost. A message is either
+// returned by a function or stays in the queue.
+//
+// # 😱 Errors
+//
+//   - [ErrEmpty]: no channels are passed into the function.
+//   - [ErrClosed]: a channel was closed.
+//   - Another: cancelation cause returned by ctx.Err().
+//
+// # 🍽 What is starvation
+//
+// Imagine that you iterate through a list of channels and return an element
+// from the first one that is available. Since the order of channels is always
+// the same, if a value is always available in a multiple channels, you'll be
+// selecting only from the first one. In other words, you never select from other
+// channels as long as the first one always has a value for you. It might result
+// in a situation when out of multiplt jobs you start only one is not blocked.
+//
+// This situation is called "[starvation]". To avoid that, the element in
+// select statement, according to the [Go specification],
+// "is chosen via a uniform pseudo-random selection".
+//
+// This function preserves that behavior by using internally
+// a dynamically created (using [reflect]) select statement.
+//
+// [starvation]: https://en.wikipedia.org/wiki/Starvation_(computer_science)
+// [Go specification]: https://go.dev/ref/spec#Select_statements
+func FirstC[T any](ctx context.Context, cs ...<-chan T) (T, error) {
+	// try to use a regular select if a small number of channels is passed
+	switch len(cs) {
+	case 0:
+		return *new(T), ErrEmpty
+	case 1:
+		select {
+		case v, ok := <-cs[0]:
+			if !ok {
+				return *new(T), ErrClosed
+			}
+			return v, nil
+		case <-ctx.Done():
+			return *new(T), ctx.Err()
+		}
+	}
+
+	cases := make([]reflect.SelectCase, 0, len(cs)+1)
+	cases = append(cases, reflect.SelectCase{
+		Dir:  reflect.SelectRecv,
+		Chan: reflect.ValueOf(ctx.Done()),
+	})
+	for _, c := range cs {
+		cases = append(cases, reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(c),
+		})
+	}
+	chosen, rval, ok := reflect.Select(cases)
+	if chosen == 0 {
+		var v T
+		return v, ctx.Err()
+	}
+	val := rval.Interface().(T)
+	if !ok {
+		return val, ErrClosed
+	}
+	return val, nil
+}
+
+// MergeC merges multiple channels into one.
+//
+// The order in which elements are merged from different channels
+// is not guaranteed.
+//
+// ⏹️ Internally, the function starts a goroutine per input channel.
+// Each of these goroutines finishes either when their input channel is closed.
+// or when the ctx context is cancelled.
+// The returned channel is closed when all of these goroutines finish.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutines will be blocked and won't consume elements
+// from the input channels until the value from the output channel
+// is consumed by another goroutine.
+func MergeC[T any](ctx context.Context, cs ...<-chan T) chan T {
+	res := make(chan T)
+
+	// make sure the result channel is closed
+	// when all input channels are closed
+	wg := sync.WaitGroup{}
+	wg.Add(len(cs))
+	go func() {
+		wg.Wait()
+		close(res)
+	}()
+
+	echo := func(c <-chan T) {
+		wg.Done()
+		for {
+			select {
+			case v, ok := <-c:
+				if !ok {
+					return
+				}
+				select {
+				case res <- v:
+				case <-ctx.Done():
+					return
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+
+	for _, c := range cs {
+		go echo(c)
+	}
+	return res
+}
+
+// Pop reads a value from the channel (with context).
+//
+// The function is blocking. It will wait and return
+// in one of the following conditions:
+//
+//  1. ⏹️ The context is canceled.
+//  2. ⏹️ The channel is closed.
+//  3. There is a value pushed into the channel.
+//
+// In the first two cases, the second return value (called "more" or "ok") is "false".
+// Otherwise, if a value is succesfully pulled from the channel, it is "true".
+//
+// Reads from nil channels block forever. So, if a nil channel is passed,
+// the function will exit only when the context is canceled.
+func Pop[T any](ctx context.Context, c <-chan T) (T, bool) {
+	select {
+	case v, more := <-c:
+		return v, more
+	case <-ctx.Done():
+		return *new(T), false
+	}
+}
+
+// Push writes the value into the channel (with context).
+//
+// ⚠️ Experimental! Behavior of this function might change in the future
+// or the function can be removed altogether.
+// It's not clear yet what's the best approach for when the target channel is closed.
+// By default, Go panics in this case, which might be not good in some situations.
+// Also, using this function might cause situations when the canceled context
+// will be ignored by the target function instead of exiting.
+func Push[T any](ctx context.Context, c chan<- T, v T) {
+	select {
+	case c <- v:
+	case <-ctx.Done():
+	}
+}
+
+// WithContext creates an echo channel of the given one that can be canceled with ctx.
+//
+// This can be useful in 2 scenarios:
+//
+//  1. To be able to cancel any function in this package
+//     without closing the original channel.
+//  2. For simpler iteration through channels with support for cancellation.
+//     This pattern is descirbed in the "Concurrency in Go" book
+//     in "The or-done-channel" chapter (page 119).
+//
+// ⏹️ Internally, the function starts a goroutine
+// that copies values from the input channel into the output one.
+// This goroutine finishes when the input channel is closed
+// or the ctx context is canceled.
+// The returned channel is closed when this goroutine finishes.
+//
+// ⏸️ The returned channel is unbuffered.
+// The goroutine will be blocked and won't consume elements
+// from the input channel until the value from the output channel
+// is consumed by another goroutine.
+func WithContext[T any](c <-chan T, ctx context.Context) chan T {
+	result := make(chan T)
+	go func() {
+		defer close(result)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case val, more := <-c:
+				if !more {
+					return
+				}
+				select {
+				case result <- val:
+				case <-ctx.Done():
+				}
+			}
+		}
+	}()
+	return result
+}

--- a/channels/channel_ctx_test.go
+++ b/channels/channel_ctx_test.go
@@ -255,6 +255,7 @@ func TestWithContext_Cancellation(t *testing.T) {
 	c1 <- 12
 	c1 <- 13
 	wg.Wait()
+	// Race condition
 	is.Equal(r, []int{11, 12})
 	close(c1)
 }

--- a/channels/channel_ctx_test.go
+++ b/channels/channel_ctx_test.go
@@ -1,0 +1,270 @@
+package channels_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/life4/genesis/channels"
+	"github.com/matryer/is"
+)
+
+func TestFirstC(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+	ctx := context.Background()
+	f := func(n, i int) {
+		csW := make([]chan<- int, n)
+		csR := make([]<-chan int, n)
+		for i := 0; i < n; i++ {
+			c := make(chan int)
+			csW[i] = c
+			csR[i] = c
+		}
+		go func() { csW[i] <- 12 }()
+		v, err := channels.FirstC(ctx, csR...)
+		is.NoErr(err)
+		is.Equal(v, 12)
+	}
+	for n := 1; n < 10; n++ {
+		for i := 0; i < n; i++ {
+			f(n, i)
+		}
+	}
+
+	_, err := channels.FirstC[int](ctx)
+	is.Equal(err, channels.ErrEmpty)
+}
+
+func TestFirstC_Cancellation(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+	ctx := context.Background()
+
+	// one closed channel
+	c1 := make(chan int)
+	close(c1)
+	_, err := channels.FirstC(ctx, c1)
+	is.Equal(err, channels.ErrClosed)
+
+	// two channels, one closed
+	c2 := make(chan int)
+	_, err = channels.FirstC(ctx, c2, c1)
+	is.Equal(err, channels.ErrClosed)
+
+	// one channel, context cancelled on wait
+	ctx2, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = channels.FirstC(ctx2, c2)
+	is.Equal(err, context.Canceled)
+
+	// two channels, context cancelled on wait
+	c3 := make(chan int)
+	c4 := make(chan int)
+	ctx3, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = channels.FirstC(ctx3, c3, c4)
+	is.Equal(err, context.Canceled)
+}
+
+func TestFirstC_Starvation(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	nChannels := 50
+	nMessages := 50
+	bufSize := 2
+
+	// create channels
+	csW := make([]chan<- int, nChannels)
+	csR := make([]<-chan int, nChannels)
+	for i := 0; i < nChannels; i++ {
+		c := make(chan int, bufSize)
+		csW[i] = c
+		csR[i] = c
+	}
+
+	// For each channel, start a job that will emit
+	// in the channel this channel's ID.
+	ctx, cancel := context.WithCancel(context.Background())
+	for i := 0; i < nChannels; i++ {
+		go func(i int) {
+			for m := 0; m < nMessages; m++ {
+				select {
+				case csW[i] <- i:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}(i)
+	}
+
+	// Calculate how many messages are received from each channel.
+	nReceived := make(map[int]uint32)
+	for k := 0; k < nChannels*4; k++ {
+		i, err := channels.FirstC(context.Background(), csR...)
+		is.NoErr(err)
+		nReceived[i] += 1
+	}
+
+	// Check if there are any starved channels.
+	// A starved channel is the one that couldn't get
+	// any messages selected from it.
+	cancel()
+	for i, n := range nReceived {
+		if n == 0 {
+			t.Errorf("channel %d is starved (n=%d)", i, n)
+		}
+	}
+}
+
+func TestMergeC(t *testing.T) {
+	is := is.New(t)
+
+	// no channels passed
+	ctx := context.Background()
+	c1 := channels.MergeC[int](ctx)
+	_, more := <-c1
+	is.True(!more)
+
+	// passed channels are all closed
+	c2 := make(chan int)
+	c3 := make(chan int)
+	close(c2)
+	close(c3)
+	c4 := channels.MergeC(ctx, c2, c3)
+	_, more = <-c4
+	is.True(!more)
+
+	// one channel
+	c5 := make(chan int)
+	go func() {
+		c5 <- 42
+		close(c5)
+	}()
+	c6 := channels.MergeC(ctx, c5)
+	v := <-c6
+	is.Equal(v, 42)
+	_, more = <-c6
+	is.True(!more)
+
+	// cancel on read
+	ctx2, cancel := context.WithCancel(context.Background())
+	c7 := channels.MergeC(ctx2, make(<-chan int))
+	cancel()
+	_, more = <-c7
+	is.True(!more)
+
+	// cancel on write
+	ctx3, cancel := context.WithCancel(context.Background())
+	c8 := make(chan int)
+	c9 := channels.MergeC(ctx3, c8)
+	c8 <- 42
+	cancel()
+	// Potential race? Let's see if it get flaky.
+	_, more = <-c9
+	is.True(!more)
+}
+
+func TestPop(t *testing.T) {
+	is := is.New(t)
+
+	// exit on canceled context
+	c := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	v, ok := channels.Pop(ctx, c)
+	is.True(!ok)
+	is.Equal(v, 0)
+
+	// succesful read
+	ctx = context.Background()
+	go func() { c <- 12 }()
+	v, ok = channels.Pop(ctx, c)
+	is.True(ok)
+	is.Equal(v, 12)
+
+	// exit on closed channel
+	ctx = context.Background()
+	close(c)
+	v, ok = channels.Pop(ctx, c)
+	is.True(!ok)
+	is.Equal(v, 0)
+}
+
+func TestPush(t *testing.T) {
+	// exit on canceled context
+	c := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	channels.Push(ctx, c, 11)
+
+	// push into the channel when there is someone to read
+	ctx = context.Background()
+	go channels.Push(ctx, c, 12)
+	is := is.New(t)
+	is.Equal(<-c, 12)
+}
+
+// WithContext should echo everything from the input channel
+// and close the resulting channel when the input one is closed.
+func TestWithContext_NoCancellation(t *testing.T) {
+	is := is.New(t)
+	c1 := make(chan int)
+	c2 := channels.WithContext(c1, context.Background())
+
+	r := make([]int, 0)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range c2 {
+			r = append(r, i)
+		}
+	}()
+
+	c1 <- 11
+	c1 <- 12
+	c1 <- 13
+	close(c1)
+	wg.Wait()
+	is.Equal(r, []int{11, 12, 13})
+}
+
+// WithContext should exit on cancellation.
+func TestWithContext_Cancellation(t *testing.T) {
+	is := is.New(t)
+	c1 := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	c2 := channels.WithContext(c1, ctx)
+
+	r := make([]int, 0)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := range c2 {
+			r = append(r, i)
+			if i == 12 {
+				cancel()
+			}
+		}
+	}()
+
+	c1 <- 11
+	c1 <- 12
+	c1 <- 13
+	wg.Wait()
+	is.Equal(r, []int{11, 12})
+	close(c1)
+}
+
+func TestWithContext_CancelWaitingInput(t *testing.T) {
+	is := is.New(t)
+	c1 := make(chan int)
+	ctx, cancel := context.WithCancel(context.Background())
+	c2 := channels.WithContext(c1, ctx)
+	cancel()
+	_, more := <-c2
+	is.True(!more)
+}

--- a/channels/channel_test.go
+++ b/channels/channel_test.go
@@ -2,7 +2,6 @@ package channels_test
 
 import (
 	"context"
-	"sync"
 	"testing"
 
 	"github.com/life4/genesis/channels"
@@ -212,115 +211,6 @@ func TestFirst(t *testing.T) {
 	is.Equal(v, 42)
 }
 
-func TestFirstC(t *testing.T) {
-	t.Parallel()
-	is := is.New(t)
-	ctx := context.Background()
-	f := func(n, i int) {
-		csW := make([]chan<- int, n)
-		csR := make([]<-chan int, n)
-		for i := 0; i < n; i++ {
-			c := make(chan int)
-			csW[i] = c
-			csR[i] = c
-		}
-		go func() { csW[i] <- 12 }()
-		v, err := channels.FirstC(ctx, csR...)
-		is.NoErr(err)
-		is.Equal(v, 12)
-	}
-	for n := 1; n < 10; n++ {
-		for i := 0; i < n; i++ {
-			f(n, i)
-		}
-	}
-
-	_, err := channels.FirstC[int](ctx)
-	is.Equal(err, channels.ErrEmpty)
-}
-
-func TestFirstC_Cancellation(t *testing.T) {
-	t.Parallel()
-	is := is.New(t)
-	ctx := context.Background()
-
-	// one closed channel
-	c1 := make(chan int)
-	close(c1)
-	_, err := channels.FirstC(ctx, c1)
-	is.Equal(err, channels.ErrClosed)
-
-	// two channels, one closed
-	c2 := make(chan int)
-	_, err = channels.FirstC(ctx, c2, c1)
-	is.Equal(err, channels.ErrClosed)
-
-	// one channel, context cancelled on wait
-	ctx2, cancel := context.WithCancel(context.Background())
-	cancel()
-	_, err = channels.FirstC(ctx2, c2)
-	is.Equal(err, context.Canceled)
-
-	// two channels, context cancelled on wait
-	c3 := make(chan int)
-	c4 := make(chan int)
-	ctx3, cancel := context.WithCancel(context.Background())
-	cancel()
-	_, err = channels.FirstC(ctx3, c3, c4)
-	is.Equal(err, context.Canceled)
-}
-
-func TestFirstC_Starvation(t *testing.T) {
-	t.Parallel()
-	is := is.New(t)
-
-	nChannels := 50
-	nMessages := 50
-	bufSize := 2
-
-	// create channels
-	csW := make([]chan<- int, nChannels)
-	csR := make([]<-chan int, nChannels)
-	for i := 0; i < nChannels; i++ {
-		c := make(chan int, bufSize)
-		csW[i] = c
-		csR[i] = c
-	}
-
-	// For each channel, start a job that will emit
-	// in the channel this channel's ID.
-	ctx, cancel := context.WithCancel(context.Background())
-	for i := 0; i < nChannels; i++ {
-		go func(i int) {
-			for m := 0; m < nMessages; m++ {
-				select {
-				case csW[i] <- i:
-				case <-ctx.Done():
-					return
-				}
-			}
-		}(i)
-	}
-
-	// Calculate how many messages are received from each channel.
-	nReceived := make(map[int]uint32)
-	for k := 0; k < nChannels*4; k++ {
-		i, err := channels.FirstC(context.Background(), csR...)
-		is.NoErr(err)
-		nReceived[i] += 1
-	}
-
-	// Check if there are any starved channels.
-	// A starved channel is the one that couldn't get
-	// any messages selected from it.
-	cancel()
-	for i, n := range nReceived {
-		if n == 0 {
-			t.Errorf("channel %d is starved (n=%d)", i, n)
-		}
-	}
-}
-
 func TestFlatten(t *testing.T) {
 	is := is.New(t)
 	chIn := make(chan (<-chan int))
@@ -431,54 +321,6 @@ func TestMerge(t *testing.T) {
 	is.True(!more)
 }
 
-func TestMergeC(t *testing.T) {
-	is := is.New(t)
-
-	// no channels passed
-	ctx := context.Background()
-	c1 := channels.MergeC[int](ctx)
-	_, more := <-c1
-	is.True(!more)
-
-	// passed channels are all closed
-	c2 := make(chan int)
-	c3 := make(chan int)
-	close(c2)
-	close(c3)
-	c4 := channels.MergeC(ctx, c2, c3)
-	_, more = <-c4
-	is.True(!more)
-
-	// one channel
-	c5 := make(chan int)
-	go func() {
-		c5 <- 42
-		close(c5)
-	}()
-	c6 := channels.MergeC(ctx, c5)
-	v := <-c6
-	is.Equal(v, 42)
-	_, more = <-c6
-	is.True(!more)
-
-	// cancel on read
-	ctx2, cancel := context.WithCancel(context.Background())
-	c7 := channels.MergeC(ctx2, make(<-chan int))
-	cancel()
-	_, more = <-c7
-	is.True(!more)
-
-	// cancel on write
-	ctx3, cancel := context.WithCancel(context.Background())
-	c8 := make(chan int)
-	c9 := channels.MergeC(ctx3, c8)
-	c8 <- 42
-	cancel()
-	// Potential race? Let's see if it get flaky.
-	_, more = <-c9
-	is.True(!more)
-}
-
 func TestMin(t *testing.T) {
 	is := is.New(t)
 	f := func(given []int, expected int, expectedErr error) {
@@ -497,46 +339,6 @@ func TestMin(t *testing.T) {
 	f([]int{4, 1, 2}, 1, nil)
 	f([]int{1, 2, 4}, 1, nil)
 	f([]int{4, 2, 1}, 1, nil)
-}
-
-func TestPop(t *testing.T) {
-	is := is.New(t)
-
-	// exit on canceled context
-	c := make(chan int)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	v, ok := channels.Pop(ctx, c)
-	is.True(!ok)
-	is.Equal(v, 0)
-
-	// succesful read
-	ctx = context.Background()
-	go func() { c <- 12 }()
-	v, ok = channels.Pop(ctx, c)
-	is.True(ok)
-	is.Equal(v, 12)
-
-	// exit on closed channel
-	ctx = context.Background()
-	close(c)
-	v, ok = channels.Pop(ctx, c)
-	is.True(!ok)
-	is.Equal(v, 0)
-}
-
-func TestPush(t *testing.T) {
-	// exit on canceled context
-	c := make(chan int)
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	channels.Push(ctx, c, 11)
-
-	// push into the channel when there is someone to read
-	ctx = context.Background()
-	go channels.Push(ctx, c, 12)
-	is := is.New(t)
-	is.Equal(<-c, 12)
 }
 
 func TestReduce(t *testing.T) {
@@ -681,68 +483,5 @@ func TestWithBuffer(t *testing.T) {
 
 	close(c1)
 	_, more := <-c1
-	is.True(!more)
-}
-
-// WithContext should echo everything from the input channel
-// and close the resulting channel when the input one is closed.
-func TestWithContext_NoCancellation(t *testing.T) {
-	is := is.New(t)
-	c1 := make(chan int)
-	c2 := channels.WithContext(c1, context.Background())
-
-	r := make([]int, 0)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := range c2 {
-			r = append(r, i)
-		}
-	}()
-
-	c1 <- 11
-	c1 <- 12
-	c1 <- 13
-	close(c1)
-	wg.Wait()
-	is.Equal(r, []int{11, 12, 13})
-}
-
-// WithContext should exit on cancellation.
-func TestWithContext_Cancellation(t *testing.T) {
-	is := is.New(t)
-	c1 := make(chan int)
-	ctx, cancel := context.WithCancel(context.Background())
-	c2 := channels.WithContext(c1, ctx)
-
-	r := make([]int, 0)
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := range c2 {
-			r = append(r, i)
-			if i == 12 {
-				cancel()
-			}
-		}
-	}()
-
-	c1 <- 11
-	c1 <- 12
-	c1 <- 13
-	wg.Wait()
-	is.Equal(r, []int{11, 12})
-	close(c1)
-}
-
-func TestWithContext_CancelWaitingInput(t *testing.T) {
-	is := is.New(t)
-	c1 := make(chan int)
-	ctx, cancel := context.WithCancel(context.Background())
-	c2 := channels.WithContext(c1, ctx)
-	cancel()
-	_, more := <-c2
 	is.True(!more)
 }

--- a/channels/doc.go
+++ b/channels/doc.go
@@ -70,7 +70,8 @@
 // In other languages this is done using iterators but in Go the only infinite iterator
 // we have is channel.
 //
-// If you want to stop a generator, cancel the context you have passed in it.
+// If you want to stop a generator (terminate the goroutine it started
+// and close the channel), cancel the context you have passed in it.
 //
 // Available functions:
 //

--- a/channels/doc.go
+++ b/channels/doc.go
@@ -1,17 +1,130 @@
 // Package channels provides generic functions for channels.
 //
-// The symbol ⏹️ indicates paragraph describing cancellation
-// of goroutines and channels that the function creates.
-// Most of the functions in the package are canceled
-// when the passed in channel is closed.
-// If you want to cancel them using a Context instead,
-// wrap the passed in channel into [WithContext].
+// # ☎️ Naming
 //
-// The symbol ⏸️ indicates a notice about unbuffered channels.
-// All functions in the package return unbuffered channels,
-// regardless of if the input channel is buffered or not.
-// If you want to make the returned channel buffered,
-// wrap it into [WithBuffer].
+// Most of the functions provide two version: a regular one and one with suffix C.
+// The latter also accepts a [context.Context] value as the first argument, and you should
+// always prefer it over the regular function. The reason is that if the function
+// accepts a channel and returns another one and you close the input channel,
+// the internal goroutine that the function starts might be blocked trying to write
+// into the output channel, and if you never read values from it, you'll have
+// a goroutine leak.
 //
-// The symbol 😱 indicates information about errors that the function may return.
+// Generator functions producing infinite sequence of values (like [Counter])
+// have only one version and always require a context because that's the only way
+// how you can cancel them.
+//
+// # ⏹️ Function termination
+//
+// Most of the functions in the package accept a channel, return a channel,
+// and create a goroutine to read messages from the input channel and propagate them
+// (usually with some changes) into the output one. Some (like [TakeC]) do all three of these,
+// some (like [ToSliceC]) only accept a channel, some (like [Counter]) only start a goroutine
+// and return a channel, etc. Which of these apply to the function is described in the
+// function's documentation.
+//
+// Here is what you need to know:
+//
+//   - If a function starts a goroutine, it returns immediately, and all termination rules
+//     described below apply to the goroutine instead of the original function.
+//   - If the function creates and returns a channel, this channel is closed
+//     when the goroutine terminates.
+//   - If the function accepts a [context.Context], the goroutine is terminated
+//     when the context is cancelled.
+//   - If the input channel is closed and the goroutine tries to read from it,
+//     the goroutine is terminated.
+//   - ⚠️ IMPORTANT: If the goroutine is blocked trying to write into the output channel
+//     and the input channel is closed, the goroutine will not terminate until
+//     another goroutine reads from the output channel. This is why you should always
+//     either use context and cancell the goroutine through it or make sure to read
+//     everything from the output channel.
+//
+// # 🍾 Buffered channels
+//
+// All functions in the package (except [WithBuffer]) return a unbuffered channel.
+// That means, they won't do anything and won't read values from the input channel
+// if you don't read values from their output channel.
+// If you want to make the output channel buffered, use [WithBuffer].
+//
+// # 😱 Error handling
+//
+// The only functions that return an error on the channel cancellation
+// (either [context.Canceled] or [context.Cause]) are [FirstC], [MaxC], and [MinC].
+// All other functions simply terminate on cancellation, and it's on you to check
+// the context for errors (using [context.Context.Err]).
+//
+// The reason for this is that most of the function start a goroutine producing values,
+// and that's the only communication channel the goroutine has. So, the only way for
+// the goroutine to return an error would be to emit it in the output channel,
+// and handling such errors would be tedious.
+//
+// Available errors:
+//
+//   - [ErrEmpty] is returned when channel is closed without any elements being sent.
+//   - [ErrClosed] is returned by [FirstC] (and [First]) when one of the passed channels
+//     is closed.
+//
+// # 🖨 Sequence generators
+//
+// These are the functions that make a channel and emit in it values until canceled.
+// In other languages this is done using iterators but in Go the only infinite iterator
+// we have is channel.
+//
+// If you want to stop a generator, cancel the context you have passed in it.
+//
+// Available functions:
+//
+//   - [Counter](ctx, start, step)
+//   - [Exponential](ctx, start, factor)
+//   - [Iterate](ctx, value, func)
+//   - [Range](ctx, start, end, step)
+//   - [Repeat](ctx, value)
+//   - [Replicate](ctx, value, n)
+//
+// # 📥 Working with channels
+//
+// All these functions accept a channel (or multiple) as an input.
+//
+// 🏃 Functions that return a channel and start an internal goroutine
+// producing values into the channel:
+//
+//   - [ChunkEvery] and [ChunkEveryC]
+//   - [Drop] and [DropC]
+//   - [Filter] and [FilterC]
+//   - [Flatten] and [FlattenC]
+//   - [Map] and [MapC]
+//   - [Merge] and [MergeC]
+//   - [Scan] and [ScanC]
+//   - [Take] and [TakeC]
+//   - [Tee] and [TeeC]
+//   - [WithBuffer] and [WithBufferC]
+//   - [WithContext]
+//
+// ✋ Functions that block until they produce a result (or until they are canceled):
+//
+//   - [Any] and [AnyC]
+//   - [All] and [AllC]
+//   - [Count] and [CountC]
+//   - [Each] and [EachC]
+//   - [Echo] and [EchoC]
+//   - [First] and [FirstC]
+//   - [Max] and [MaxC]
+//   - [Min] and [MinC]
+//   - [Reduce] and [ReduceC]
+//   - [Sum] and [SumC]
+//   - [ToSlice] and [ToSliceC]
+//
+// # 🛟 Helpers
+//
+// These are little functions that help working with channels.
+// They don't iterate over values in the channel.
+//
+// Available functions:
+//
+//   - [BufferSize] returns the channel's buffer size.
+//   - [Close] closes the channel and never panics.
+//   - [IsEmpty] tells if there are no messages in the channel.
+//   - [IsFull] tells if the channel has reached its capacity.
+//   - [Pop] is a blocking read from the channel that can be canceled.
+//   - [Push] is a blocking write into a channel that can be canceled.
 package channels

--- a/channels/sequence.go
+++ b/channels/sequence.go
@@ -6,13 +6,7 @@ import (
 	"github.com/life4/genesis/constraints"
 )
 
-// Counter is like Range, but infinite.
-//
-// ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is canceled.
-// The returned channel is closed when this goroutine finishes.
-//
-// ⏸️ The returned channel is unbuffered.
+// Counter is like [Range], but infinite.
 func Counter[T constraints.Integer](ctx context.Context, start T, step T) chan T {
 	c := make(chan T)
 	go func() {
@@ -29,14 +23,7 @@ func Counter[T constraints.Integer](ctx context.Context, start T, step T) chan T
 	return c
 }
 
-// Exponential generates elements from start with
-// multiplication of value on factor on every step.
-//
-// ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is canceled.
-// The returned channel is closed when this goroutine finishes.
-//
-// ⏸️ The returned channel is unbuffered.
+// Exponential generates elements from start with multiplication of value by factor on every step.
 func Exponential[T constraints.Integer](ctx context.Context, start T, factor T) chan T {
 	c := make(chan T)
 	go func() {
@@ -54,12 +41,6 @@ func Exponential[T constraints.Integer](ctx context.Context, start T, factor T) 
 }
 
 // Iterate returns an infinite list of repeated applications of f to val.
-//
-// ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is canceled.
-// The returned channel is closed when this goroutine finishes.
-//
-// ⏸️ The returned channel is unbuffered.
 func Iterate[T constraints.Integer](ctx context.Context, val T, f func(val T) T) chan T {
 	c := make(chan T)
 	go func() {
@@ -77,12 +58,6 @@ func Iterate[T constraints.Integer](ctx context.Context, val T, f func(val T) T)
 }
 
 // Range generates elements from start to end with given step.
-//
-// ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is canceled.
-// The returned channel is closed when this goroutine finishes.
-//
-// ⏸️ The returned channel is unbuffered.
 func Range[T constraints.Integer](ctx context.Context, start T, end T, step T) chan T {
 	c := make(chan T)
 	pos := start <= end
@@ -97,12 +72,6 @@ func Range[T constraints.Integer](ctx context.Context, start T, end T, step T) c
 }
 
 // Repeat returns channel that produces val infinite times.
-//
-// ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is canceled.
-// The returned channel is closed when this goroutine finishes.
-//
-// ⏸️ The returned channel is unbuffered.
 func Repeat[T constraints.Integer](ctx context.Context, val T) chan T {
 	c := make(chan T)
 	go func() {
@@ -121,11 +90,7 @@ func Repeat[T constraints.Integer](ctx context.Context, val T) chan T {
 
 // Replicate returns channel that produces val n times.
 //
-// ⏹️ Internally, the function starts a goroutine.
-// This goroutine finishes when the ctx is canceled.
-// The returned channel is closed when this goroutine finishes.
-//
-// ⏸️ The returned channel is unbuffered.
+// Use [Repeat] if you need to generate the value forever.
 func Replicate[T constraints.Integer](ctx context.Context, val T, n int) chan T {
 	c := make(chan T)
 	go func() {

--- a/lambdas/checks.go
+++ b/lambdas/checks.go
@@ -47,9 +47,9 @@ func IsNotEmpty[T any](items []T) bool {
 //
 // A few examples:
 //
-// 	 + 0 for int and float
-// 	 + "" for string
-// 	 + nil for slice
+//   - 0 for int and float
+//   - "" for string
+//   - nil for slice
 func IsDefault[T comparable](value T) bool {
 	var def T
 	return value == def
@@ -59,9 +59,9 @@ func IsDefault[T comparable](value T) bool {
 //
 // A few examples:
 //
-// 	 + 0 for int and float
-// 	 + "" for string
-// 	 + nil for slice
+//   - 0 for int and float
+//   - "" for string
+//   - nil for slice
 func IsNotDefault[T comparable](value T) bool {
 	var def T
 	return value != def

--- a/slices/async_slice.go
+++ b/slices/async_slice.go
@@ -265,13 +265,10 @@ func MapAsync[S ~[]T, T any, G any](items S, workers int, f func(el T) G) []G {
 //
 // An example for sum:
 //
-// ```
-// 1 2 3 4 5
-//  3   7  5
-//   10    5
-//      15
-// ```
-//
+//	1 2 3 4 5
+//	 3   7  5
+//	  10    5
+//	     15
 func ReduceAsync[S ~[]T, T any](items S, workers int, f func(left T, right T) T) T {
 	if len(items) == 0 {
 		var tmp T
@@ -279,7 +276,7 @@ func ReduceAsync[S ~[]T, T any](items S, workers int, f func(left T, right T) T)
 	}
 
 	state := make([]T, len(items))
-	state = append(state, items...)
+	copy(state, items)
 	wg := sync.WaitGroup{}
 
 	worker := func(jobs <-chan int, result chan<- T) {


### PR DESCRIPTION
This is a big rewrite of almost all functions in the channels package. It introduces a new function with `C` suffix for every function. For example, `First` and `FirstC`. This new function accepts a context as the first argument and respects this context in all blocking operations.

Also:

1. Add golangci-lint config.
2. Rewrite documentation. The module-level documentation for channels now covers all you need to know.
3. Add some new functions for channels. `EchoC` for sure is new, maybe some others too. I didn't keep track >.<