### PR TITLE
slices: misc improvements to godoc

### DIFF
--- a/slices/async_slice.go
+++ b/slices/async_slice.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 )
 
-// AllAsync returns true if f returns true for all elements in slice.
+// AllAsync returns true if f returns true for all elements in items.
 //
 // This is an asynchronous function. It will spawn as many goroutines as you specify
 // in the `workers` argument. Set it to zero to spawn a new goroutine for each item.
@@ -69,7 +69,7 @@ func AllAsync[S ~[]T, T any](items S, workers int, f func(el T) bool) bool {
 	return true
 }
 
-// AnyAsync returns true if f returns true for any element from slice
+// AnyAsync returns true if f returns true for any element in items.
 //
 // This is an asynchronous function. It will spawn as many goroutines as you specify
 // in the `workers` argument. Set it to zero to spawn a new goroutine for each item.
@@ -133,7 +133,7 @@ func AnyAsync[S ~[]T, T any](items S, workers int, f func(el T) bool) bool {
 	return false
 }
 
-// EachAsync calls f for every element from slice
+// EachAsync calls f for each element in items.
 //
 // This is an asynchronous function. It will spawn as many goroutines as you specify
 // in the `workers` argument. Set it to zero to spawn a new goroutine for each item.
@@ -167,7 +167,7 @@ func EachAsync[S ~[]T, T any](items S, workers int, f func(el T)) {
 	wg.Wait()
 }
 
-// FilterAsync returns slice of element for which f returns true
+// FilterAsync returns a slice containing only items where f returns true
 //
 // This is an asynchronous function. It will spawn as many goroutines as you specify
 // in the `workers` argument. Set it to zero to spawn a new goroutine for each item.
@@ -215,7 +215,7 @@ func FilterAsync[S ~[]T, T any](items S, workers int, f func(el T) bool) S {
 	return result
 }
 
-// MapAsync applies F to all elements in slice of T and returns slice of results
+// MapAsync applies f to all elements in items and returns a slice of the results.
 //
 // This is an asynchronous function. It will spawn as many goroutines as you specify
 // in the `workers` argument. Set it to zero to spawn a new goroutine for each item.
@@ -253,7 +253,7 @@ func MapAsync[S ~[]T, T any, G any](items S, workers int, f func(el T) G) []G {
 	return result
 }
 
-// ReduceAsync reduces slice to a single value with f.
+// ReduceAsync reduces items to a single value with f.
 //
 // This is an asynchronous function. It will spawn as many goroutines as you specify
 // in the `workers` argument. Set it to zero to spawn a new goroutine for each item.

--- a/slices/slice.go
+++ b/slices/slice.go
@@ -393,7 +393,7 @@ func Prepend[S ~[]T, T any](target S, items ...T) S {
 	return Concat(items, target)
 }
 
-// Product returns cortesian product of elements
+// Product returns the cartesian product of items to itself, repeat times.
 func Product[S ~[]T, T any](items S, repeat int) chan []T {
 	c := make(chan []T, 1)
 	go func() {
@@ -406,7 +406,7 @@ func Product[S ~[]T, T any](items S, repeat int) chan []T {
 	return c
 }
 
-// product is a core implementation for Product
+// product is a core implementation for [Product]
 func product[S ~[]T, T any](items S, c chan []T, repeat int, left []T, pos int) {
 	// iterate over the last array
 	if pos == repeat-1 {

--- a/slices/slice.go
+++ b/slices/slice.go
@@ -26,9 +26,9 @@ func Choice[S ~[]T, T any](items S, seed int64) (T, error) {
 	return items[i], nil
 }
 
-// ChunkEvery splits items into groups the length of count each.
+// ChunkEvery splits items into groups of length count.
 //
-// If items can't be split evenly, the final chunk will be the remaining elements.
+// If items can't be split evenly, the final chunk will contain the remaining elements.
 func ChunkEvery[S ~[]T, T any](items S, count int) ([]S, error) {
 	chunks := make([]S, 0)
 	if count <= 0 {
@@ -48,7 +48,7 @@ func ChunkEvery[S ~[]T, T any](items S, count int) ([]S, error) {
 	return chunks, nil
 }
 
-// Contains returns true if el in arr.
+// Contains returns true if el is in items.
 func Contains[S ~[]T, T comparable](items S, el T) bool {
 	for _, val := range items {
 		if val == el {
@@ -67,7 +67,7 @@ func Copy[S ~[]T, T any](items S) S {
 	return append(res, items...)
 }
 
-// Count return count of el occurrences in arr.
+// Count return the count of el occurrences in items.
 func Count[S ~[]T, T comparable](items S, el T) int {
 	count := 0
 	for _, val := range items {
@@ -78,7 +78,7 @@ func Count[S ~[]T, T comparable](items S, el T) int {
 	return count
 }
 
-// Cycle is an infinite loop over slice
+// Cycle is an infinite loop over items.
 func Cycle[S ~[]T, T any](items S) chan T {
 	c := make(chan T)
 	go func() {
@@ -95,7 +95,7 @@ func Cycle[S ~[]T, T any](items S) chan T {
 	return c
 }
 
-// Dedup returns a given slice without consecutive duplicated elements
+// Dedup returns items without consecutive duplicated elements.
 func Dedup[S ~[]T, T comparable](items S) S {
 	if len(items) == 0 {
 		return items
@@ -113,7 +113,7 @@ func Dedup[S ~[]T, T comparable](items S) S {
 	return result
 }
 
-// Delete deletes the first occurrence of the element from the slice
+// Delete deletes the first occurrence of the element from items.
 func Delete[S ~[]T, T comparable](items S, element T) S {
 	if len(items) == 0 {
 		return items
@@ -129,10 +129,9 @@ func Delete[S ~[]T, T comparable](items S, element T) S {
 		result = append(result, el)
 	}
 	return result
-
 }
 
-// DeleteAll deletes all occurrences of the element from the slice
+// DeleteAll deletes all occurrences of the element from items.
 func DeleteAll[S ~[]T, T comparable](items S, element T) S {
 	if len(items) == 0 {
 		return items
@@ -149,7 +148,7 @@ func DeleteAll[S ~[]T, T comparable](items S, element T) S {
 
 }
 
-// DeleteAt returns the slice without elements on given positions
+// DeleteAt returns items without the elements in indices.
 func DeleteAt[S ~[]T, T any](items S, indices ...int) (S, error) {
 	if len(indices) == 0 || len(items) == 0 {
 		return items, nil
@@ -177,7 +176,7 @@ func DeleteAt[S ~[]T, T any](items S, indices ...int) (S, error) {
 	return result, nil
 }
 
-// DropEvery returns a slice of every nth element in the enumerable dropped,
+// DropEvery returns a slice with every nth element in items dropped,
 // starting with the first element.
 func DropEvery[S ~[]T, T any](items S, nth int, from int) (S, error) {
 	if nth <= 0 {
@@ -211,7 +210,7 @@ func DropZero[S ~[]T, T comparable](items S) S {
 	return result
 }
 
-// EndsWith returns true if slice ends with the given suffix slice.
+// EndsWith returns true if items ends with the given suffix slice.
 //
 // If suffix is empty, it returns true.
 func EndsWith[S ~[]T, T comparable](items S, suffix S) bool {
@@ -227,7 +226,7 @@ func EndsWith[S ~[]T, T comparable](items S, suffix S) bool {
 	return true
 }
 
-// Equal returns true if slices are equal.
+// Equal returns true if the slices are equal.
 func Equal[S1 ~[]T, S2 ~[]T, T comparable](items S1, other S2) bool {
 	if len(items) != len(other) {
 		return false
@@ -242,7 +241,7 @@ func Equal[S1 ~[]T, S2 ~[]T, T comparable](items S1, other S2) bool {
 
 // Grow increases the slice capacity to fit at least n more elements.
 //
-// So, for len(slice)=8 and n=2, the result will have cap at least 10.
+// So, for len(slice)=8 and n=2, the result will have a capacity of at least 10.
 //
 // The function can be used to reduce allocations when inserting more elements
 // into an existing slice.
@@ -262,7 +261,10 @@ func Index[S ~[]T, T comparable](items S, item T) (int, error) {
 	return 0, ErrNotFound
 }
 
-// InsertAt returns the items slice with the item inserted at the given index.
+// InsertAt returns items with item inserted at the given index.
+//
+// If index is beyond the length of items, ErrOutOfRange is returned.
+// If index is negative, ErrNegativeValue is returned.
 func InsertAt[S ~[]T, T any](items S, index int, item T) (S, error) {
 	result := make([]T, 0, len(items)+1)
 
@@ -289,7 +291,7 @@ func InsertAt[S ~[]T, T any](items S, index int, item T) (S, error) {
 	return result, nil
 }
 
-// Intersperse inserts el between each element of arr
+// Intersperse inserts el between each element of items.
 func Intersperse[S ~[]T, T any](items S, el T) S {
 	if len(items) == 0 {
 		return items
@@ -302,7 +304,7 @@ func Intersperse[S ~[]T, T any](items S, el T) S {
 	return result
 }
 
-// Join concatenates elements of the slice to create a single string.
+// Join concatenates elements of items to create a single string.
 func Join[S ~[]T, T any](items S, sep string) string {
 	strs := make([]string, 0, len(items))
 	for _, el := range items {
@@ -311,7 +313,7 @@ func Join[S ~[]T, T any](items S, sep string) string {
 	return strings.Join(strs, sep)
 }
 
-// Last returns the last element from the slice
+// Last returns the last element from items.
 func Last[S ~[]T, T any](items S) (T, error) {
 	if len(items) == 0 {
 		var tmp T
@@ -320,7 +322,7 @@ func Last[S ~[]T, T any](items S) (T, error) {
 	return items[len(items)-1], nil
 }
 
-// Max returns the maximal element from arr
+// Max returns the maximal element in items.
 func Max[S ~[]T, T constraints.Ordered](items S) (T, error) {
 	if len(items) == 0 {
 		var tmp T
@@ -336,7 +338,7 @@ func Max[S ~[]T, T constraints.Ordered](items S) (T, error) {
 	return max, nil
 }
 
-// Min returns the minimal element from arr
+// Min returns the minimal element from items.
 func Min[S ~[]T, T constraints.Ordered](items S) (T, error) {
 	if len(items) == 0 {
 		var tmp T
@@ -352,7 +354,7 @@ func Min[S ~[]T, T constraints.Ordered](items S) (T, error) {
 	return min, nil
 }
 
-// Permutations returns successive size-length permutations of elements from the slice.
+// Permutations returns successive size-length permutations of elements from items.
 func Permutations[S ~[]T, T any](items S, size int) chan S {
 	c := make(chan S, 1)
 	go func() {
@@ -364,7 +366,7 @@ func Permutations[S ~[]T, T any](items S, size int) chan S {
 	return c
 }
 
-// permutations is a core implementation for Permutations
+// permutations is a core implementation for Permutations.
 func permutations[S ~[]T, T any](items S, c chan S, size int, left []T, right []T) {
 	if len(left) == size || len(right) == 0 {
 		c <- left
@@ -425,7 +427,7 @@ func product[S ~[]T, T any](items S, c chan []T, repeat int, left []T, pos int) 
 	}
 }
 
-// Repeat repeats items slice n times.
+// Repeat repeats items n times.
 func Repeat[S ~[]T, T any](items S, n int) S {
 	result := make([]T, 0, len(items)*n)
 	for i := 0; i < n; i++ {
@@ -463,7 +465,7 @@ func Replace[S ~[]T, T comparable, I constraints.Integer](items S, start, end I,
 	return result, nil
 }
 
-// Reverse returns given arr in reversed order
+// Reverse returns items in reversed order.
 func Reverse[S ~[]T, T any](items S) S {
 	if len(items) <= 1 {
 		return items
@@ -475,7 +477,7 @@ func Reverse[S ~[]T, T any](items S) S {
 	return result
 }
 
-// Same returns true if all element in arr the same
+// Same returns true if all elements in items are the same.
 func Same[S ~[]T, T comparable](items S) bool {
 	if len(items) <= 1 {
 		return true
@@ -495,7 +497,7 @@ func Shrink[S ~[]T, T any](items S) S {
 	return items[:len(items):len(items)]
 }
 
-// Shuffle in random order the given elements
+// Shuffle in random order the given elements.
 //
 // This is an in-place operation, it modifies the passed slice.
 func Shuffle[S ~[]T, T any](items S, seed int64) {
@@ -512,7 +514,7 @@ func Shuffle[S ~[]T, T any](items S, seed int64) {
 	r.Shuffle(len(items), swap)
 }
 
-// Sort returns sorted slice
+// Sort returns a sorted copy of items.
 func Sort[S ~[]T, T constraints.Ordered](items S) S {
 	if len(items) <= 1 {
 		return items
@@ -524,7 +526,7 @@ func Sort[S ~[]T, T constraints.Ordered](items S) S {
 	return items
 }
 
-// Sorted returns true if slice is sorted
+// Sorted returns true if items is sorted.
 func Sorted[S ~[]T, T constraints.Ordered](items S) bool {
 	l := len(items)
 	if l <= 1 {
@@ -538,7 +540,7 @@ func Sorted[S ~[]T, T constraints.Ordered](items S) bool {
 	return true
 }
 
-// SortedUnique returns true if the slice is sorted and all items are unique.
+// SortedUnique returns true if items is sorted and all elements are unique.
 func SortedUnique[S ~[]T, T constraints.Ordered](items S) bool {
 	l := len(items)
 	if l <= 1 {
@@ -552,7 +554,7 @@ func SortedUnique[S ~[]T, T constraints.Ordered](items S) bool {
 	return true
 }
 
-// Split splits arr by sep
+// Split splits items by sep.
 func Split[S ~[]T, T comparable](items S, sep T) []S {
 	result := make([]S, 0)
 	curr := make([]T, 0)
@@ -568,8 +570,8 @@ func Split[S ~[]T, T comparable](items S, sep T) []S {
 	return result
 }
 
-// StartsWith returns true if slice starts with the given prefix slice.
-// If prefix is empty, it returns true.
+// StartsWith returns true if items starts with prefix.
+// If prefix is empty, StartsWith returns true.
 func StartsWith[S ~[]T, T comparable](items S, prefix S) bool {
 	if len(prefix) > len(items) {
 		return false
@@ -582,7 +584,7 @@ func StartsWith[S ~[]T, T comparable](items S, prefix S) bool {
 	return true
 }
 
-// Sum return sum of all elements from arr
+// Sum return sum of all elements in items.
 func Sum[S ~[]T, T constraints.Ordered](items S) T {
 	var sum T
 	for _, el := range items {
@@ -591,7 +593,7 @@ func Sum[S ~[]T, T constraints.Ordered](items S) T {
 	return sum
 }
 
-// TakeEvery returns slice of every nth elements
+// TakeEvery returns a slice containing every nth element in items.
 func TakeEvery[S ~[]T, T any](items S, nth int, from int) (S, error) {
 	if nth <= 0 {
 		return items, ErrNonPositiveValue
@@ -608,7 +610,7 @@ func TakeEvery[S ~[]T, T any](items S, nth int, from int) (S, error) {
 	return result, nil
 }
 
-// TakeRandom returns slice of count random elements from the slice
+// TakeRandom returns a slice of count random elements from items.
 func TakeRandom[S ~[]T, T any](items S, count int, seed int64) (S, error) {
 	if count > len(items) {
 		return nil, ErrOutOfRange
@@ -628,7 +630,7 @@ func TakeRandom[S ~[]T, T any](items S, count int, seed int64) (S, error) {
 	return items[:count], nil
 }
 
-// ToChannel returns channel with elements from the slice
+// ToChannel returns a channel with elements from items.
 func ToChannel[S ~[]T, T any](items S) chan T {
 	c := make(chan T)
 	go func() {
@@ -640,8 +642,8 @@ func ToChannel[S ~[]T, T any](items S) chan T {
 	return c
 }
 
-// ToKeys converts the given slice into a map where items from the slice are the keys
-// of the resulting map and all values are equal to the given `val` value.
+// ToKeys returns a map where the keys are the elements in items and all values
+// are set to val.
 func ToKeys[S ~[]K, K comparable, V any](items S, val V) map[K]V {
 	if items == nil {
 		return nil
@@ -653,8 +655,8 @@ func ToKeys[S ~[]K, K comparable, V any](items S, val V) map[K]V {
 	return result
 }
 
-// ToMap converts the given slice into a map where keys are indices and values are items
-// from the given slice.
+// ToMap converts the given slice into a map where the keys are indices and the
+// values are elements from items.
 func ToMap[S ~[]V, V any](items S) map[int]V {
 	if items == nil {
 		return nil
@@ -666,7 +668,7 @@ func ToMap[S ~[]V, V any](items S) map[int]V {
 	return result
 }
 
-// Uniq returns arr with only first occurrences of every element.
+// Uniq returns items with only the first occurrence of each unique element.
 func Uniq[S ~[]T, T comparable](items S) S {
 	if len(items) <= 1 {
 		return items
@@ -685,7 +687,7 @@ func Uniq[S ~[]T, T comparable](items S) S {
 
 }
 
-// Unique checks if each item in the given slice appears only once.
+// Unique returns true if each element in items appears only once.
 func Unique[S ~[]T, T comparable](items S) bool {
 	seen := make(map[T]struct{})
 	for _, item := range items {
@@ -698,7 +700,7 @@ func Unique[S ~[]T, T comparable](items S) bool {
 	return true
 }
 
-// Window makes sliding window for the given slice
+// Window makes a sliding window for items.
 func Window[S ~[]T, T any](items S, size int) ([]S, error) {
 	if size <= 0 {
 		return nil, ErrNonPositiveValue
@@ -711,7 +713,7 @@ func Window[S ~[]T, T any](items S, size int) ([]S, error) {
 	return result, nil
 }
 
-// Without returns the slice with filtered out element
+// Without returns items without the given elements.
 func Without[S ~[]T, T comparable](items S, elements ...T) S {
 	result := make(S, 0, len(items))
 	for _, el := range items {
@@ -728,7 +730,7 @@ func Without[S ~[]T, T comparable](items S, elements ...T) S {
 	return result
 }
 
-// Wrap makes a single element slice out of the given value
+// Wrap wraps item in a slice of the same type.
 func Wrap[T any](item T) []T {
 	return []T{item}
 }

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -253,7 +253,11 @@ func Reject[S ~[]T, T any](items S, f func(el T) bool) S {
 	return Filter(items, notF)
 }
 
-// Scan is like Reduce, but returns a slice of f results.
+// Scan applies f to acc and each element in items, feeding the output of the
+// last call into the next call, and returning a slice of the results.
+//
+// Scan is like [Reduce], but it returns a slice of the results instead of a
+// single value.
 func Scan[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) G) []G {
 	result := make([]G, 0, len(items))
 	for _, el := range items {

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -63,8 +63,8 @@ func CountBy[S ~[]T, T any](items S, f func(el T) bool) int {
 	return count
 }
 
-// DedupBy returns a given slice without consecutive elements
-// For which f returns the same result
+// DedupBy returns a copy of items, but without consecutive elements
+// for which f returns the same result.
 func DedupBy[S ~[]T, T comparable, G comparable](items S, f func(el T) G) S {
 	result := make(S, 0, len(items))
 	if len(items) == 0 {

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -139,7 +139,7 @@ func Filter[S ~[]T, T any](items S, f func(el T) bool) S {
 	return result
 }
 
-// Find returns the first element for which f returns true
+// Find returns the first element for which f returns true.
 func Find[S ~[]T, T any](items S, f func(el T) bool) (T, error) {
 	for _, el := range items {
 		if f(el) {
@@ -150,8 +150,8 @@ func Find[S ~[]T, T any](items S, f func(el T) bool) (T, error) {
 	return tmp, ErrNotFound
 }
 
-// FindIndex is like Find, but return element index instead of element itself.
-// Returns -1 if element not found
+// FindIndex returns the index of the first element for which f returns true.
+// Returns -1 if no matching element is found.
 func FindIndex[S ~[]T, T any](items S, f func(el T) bool) int {
 	for i, el := range items {
 		if f(el) {

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -112,9 +112,10 @@ func EachErr[S ~[]E, E any](items S, f func(el E) error) error {
 	return err
 }
 
-// EqualBy returns true if the cmp function returns true for any elements of the slices
-// in the matching positions. If len of the slices is different, false is returned.
-// It is similar to Any except it Zip's by two slices.
+// EqualBy returns true if the cmp function returns true for all element pairs
+// in the two slices.
+//
+// If the slices are different lengths, false is returned.
 func EqualBy[S1 ~[]E1, S2 ~[]E2, E1, E2 any](s1 S1, s2 S2, eq func(E1, E2) bool) bool {
 	if len(s1) != len(s2) {
 		return false

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -207,10 +207,9 @@ func MapFilter[S ~[]T, T any, G any](items S, f func(el T) (G, bool)) []G {
 
 // Partition splits items into two slices based on if f returns true or false.
 //
-// The first returned slice contains the items for which the given function
-// returned true, in the order as they appear in the input slice.
-// The second returned slice contains the items for which the function
-// returned false.
+// The first returned slice contains the items for which f returned true.
+// The second returned slice contains the remainder. Order is preserved in both
+// slices.
 func Partition[S ~[]T, T any](items S, f func(el T) bool) (S, S) {
 	good := make(S, 0)
 	bad := make(S, 0)

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -258,10 +258,10 @@ func Scan[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) G) []G {
 	return result
 }
 
-// SortBy sorts the items using for exah element the value returned bu the given function.
+// SortBy sorts items using the values returned by f.
 //
 // The function might be called more than once for the same element.
-// It expected to be fast and always produce the same result.
+// It is expected to be fast and always produce the same result.
 //
 // The sort is stable. If two elements have the same ordering key,
 // they are not swapped.

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -161,7 +161,7 @@ func FindIndex[S ~[]T, T any](items S, f func(el T) bool) int {
 	return -1
 }
 
-// GroupBy groups items by value returned by f.
+// GroupBy groups items by the value returned by f.
 func GroupBy[S ~[]T, T any, K comparable](items S, f func(el T) K) map[K]S {
 	result := make(map[K]S)
 	for _, el := range items {
@@ -181,7 +181,7 @@ func IndexBy[S []T, T comparable](items S, f func(T) bool) (int, error) {
 	return 0, ErrNotFound
 }
 
-// Map applies F to all elements in slice of T and returns slice of results
+// Map applies f to all elements in items and returns a slice of the results.
 func Map[S ~[]T, T any, G any](items S, f func(el T) G) []G {
 	result := make([]G, 0, len(items))
 	for _, el := range items {
@@ -190,7 +190,7 @@ func Map[S ~[]T, T any, G any](items S, f func(el T) G) []G {
 	return result
 }
 
-// MapFilter returns slice of `f` results for which `f` also returned true.
+// MapFilter returns a slice of f results for which f also returned true.
 func MapFilter[S ~[]T, T any, G any](items S, f func(el T) (G, bool)) []G {
 	result := make([]G, 0, len(items))
 	for _, el := range items {
@@ -221,7 +221,7 @@ func Partition[S ~[]T, T any](items S, f func(el T) bool) (S, S) {
 	return good, bad
 }
 
-// Reduce applies `f` to acc and every element in slice of `items` and returns `acc`.
+// Reduce applies f to acc and every element in the slice of items and returns acc.
 func Reduce[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) G) G {
 	for _, el := range items {
 		acc = f(el, acc)
@@ -229,7 +229,7 @@ func Reduce[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) G) G {
 	return acc
 }
 
-// ReduceWhile is like Reduce, but stops when f returns error
+// ReduceWhile is like Reduce, but stops when f returns an error.
 func ReduceWhile[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) (G, error)) (G, error) {
 	var err error
 	for _, el := range items {
@@ -241,7 +241,7 @@ func ReduceWhile[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) (G, e
 	return acc, nil
 }
 
-// Reject is like filter but it returns slice of T for which F returned false
+// Reject is like filter but it returns a slice of T for which f returned false.
 func Reject[S ~[]T, T any](items S, f func(el T) bool) S {
 	notF := func(el T) bool {
 		return !f(el)
@@ -249,7 +249,7 @@ func Reject[S ~[]T, T any](items S, f func(el T) bool) S {
 	return Filter(items, notF)
 }
 
-// Scan is like Reduce, but returns slice of f results
+// Scan is like Reduce, but returns a slice of f results.
 func Scan[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) G) []G {
 	result := make([]G, 0, len(items))
 	for _, el := range items {

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -6,7 +6,7 @@ import (
 	"github.com/life4/genesis/constraints"
 )
 
-// All returns true if f returns true for all elements in arr
+// All returns true if f returns true for all items.
 func All[S ~[]T, T any](items S, f func(el T) bool) bool {
 	for _, el := range items {
 		if !f(el) {
@@ -16,7 +16,7 @@ func All[S ~[]T, T any](items S, f func(el T) bool) bool {
 	return true
 }
 
-// Any returns true if f returns true for any element in arr
+// Any returns true if f returns true for any item in items.
 func Any[S ~[]T, T any](items S, f func(el T) bool) bool {
 	for _, el := range items {
 		if f(el) {
@@ -26,7 +26,7 @@ func Any[S ~[]T, T any](items S, f func(el T) bool) bool {
 	return false
 }
 
-// ChunkBy splits arr on every element for which f returns a new value.
+// ChunkBy splits items on every element for which f returns a new value.
 func ChunkBy[S ~[]T, T comparable, G comparable](items S, f func(el T) G) []S {
 	chunks := make([]S, 0)
 	if len(items) == 0 {
@@ -83,7 +83,7 @@ func DedupBy[S ~[]T, T comparable, G comparable](items S, f func(el T) G) S {
 	return result
 }
 
-// DropWhile drops elements from arr while f returns true
+// DropWhile drops elements from items while f returns true.
 func DropWhile[S ~[]T, T any](items S, f func(el T) bool) S {
 	for i, el := range items {
 		if !f(el) {
@@ -93,14 +93,14 @@ func DropWhile[S ~[]T, T any](items S, f func(el T) bool) S {
 	return []T{}
 }
 
-// Each calls f for every element from arr
+// Each calls f for each item in items.
 func Each[S ~[]T, T any](items S, f func(el T)) {
 	for _, el := range items {
 		f(el)
 	}
 }
 
-// EachErr calls f for every element from arr until f returns an error
+// EachErr calls f for each element in items until f returns an error.
 func EachErr[S ~[]E, E any](items S, f func(el E) error) error {
 	var err error
 	for _, el := range items {
@@ -160,7 +160,7 @@ func FindIndex[S ~[]T, T any](items S, f func(el T) bool) int {
 	return -1
 }
 
-// GroupBy groups element from array by value returned by f
+// GroupBy groups items by value returned by f.
 func GroupBy[S ~[]T, T any, K comparable](items S, f func(el T) K) map[K]S {
 	result := make(map[K]S)
 	for _, el := range items {
@@ -276,7 +276,7 @@ func SortBy[S ~[]T, T any, K constraints.Ordered](items S, f func(el T) K) S {
 	return items
 }
 
-// TakeWhile takes elements from arr while f returns true
+// TakeWhile takes elements from items while f returns true.
 func TakeWhile[S ~[]T, T any](items S, f func(el T) bool) S {
 	result := make(S, 0, len(items))
 	for _, el := range items {

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -223,7 +223,8 @@ func Partition[S ~[]T, T any](items S, f func(el T) bool) (S, S) {
 	return good, bad
 }
 
-// Reduce applies f to acc and every element in the slice of items and returns acc.
+// Reduce applies f to acc and each element in items, reducing the slice to a
+// single value.
 func Reduce[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) G) G {
 	for _, el := range items {
 		acc = f(el, acc)
@@ -231,7 +232,7 @@ func Reduce[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) G) G {
 	return acc
 }
 
-// ReduceWhile is like Reduce, but stops when f returns an error.
+// ReduceWhile is like [Reduce], but stops when f returns an error.
 func ReduceWhile[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) (G, error)) (G, error) {
 	var err error
 	for _, el := range items {

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -83,7 +83,7 @@ func DedupBy[S ~[]T, T comparable, G comparable](items S, f func(el T) G) S {
 	return result
 }
 
-// DropWhile drops elements from items while f returns true.
+// DropWhile drops elements from the start of items while f returns true.
 func DropWhile[S ~[]T, T any](items S, f func(el T) bool) S {
 	for i, el := range items {
 		if !f(el) {

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -244,7 +244,8 @@ func ReduceWhile[S ~[]T, T any, G any](items S, acc G, f func(el T, acc G) (G, e
 	return acc, nil
 }
 
-// Reject is like filter but it returns a slice of T for which f returned false.
+// Reject returns a slice containing only items where f returns false.
+// It is the opposite of [Filter].
 func Reject[S ~[]T, T any](items S, f func(el T) bool) S {
 	notF := func(el T) bool {
 		return !f(el)

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -190,7 +190,10 @@ func Map[S ~[]T, T any, G any](items S, f func(el T) G) []G {
 	return result
 }
 
-// MapFilter returns a slice of f results for which f also returned true.
+// MapFilter applies f to all elements in items, and returns a filtered slice of the results.
+//
+// f returns two values: the mapped value, and a boolean indicating whether the
+// result should be included in the filtered slice.
 func MapFilter[S ~[]T, T any, G any](items S, f func(el T) (G, bool)) []G {
 	result := make([]G, 0, len(items))
 	for _, el := range items {

--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -128,7 +128,7 @@ func EqualBy[S1 ~[]E1, S2 ~[]E2, E1, E2 any](s1 S1, s2 S2, eq func(E1, E2) bool)
 	return true
 }
 
-// Filter returns slice of T for which F returned true
+// Filter returns a slice containing only items where f returns true.
 func Filter[S ~[]T, T any](items S, f func(el T) bool) S {
 	result := make([]T, 0, len(items))
 	for _, el := range items {

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -97,7 +97,10 @@ func Union[S ~[]T, T comparable](left S, right S) S {
 	return Uniq(Concat(left, right))
 }
 
-// Zip returns chan of arrays of elements from given arrs on the same position.
+// Zip returns a chan of slices each containing elements from consecutive positions in each input slice.
+// The first slice in the channel will contain items[0][0], items[1][0], ..., items[n-1][0].
+// The second slice in the channel will contain items[0][1], items[1][1], ..., items[n-1][1].
+// If the slices are of unequal length, the shortest slice length will be used.
 func Zip[S ~[]T, T any](items ...S) chan S {
 	if len(items) == 0 {
 		result := make(chan S)

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -60,14 +60,14 @@ func Intersect[S1 ~[]T, S2 ~[]T, T comparable](items1 S1, items2 S2) []T {
 	return result
 }
 
-// Product returns cortesian product of elements in the given slices.
+// Product2 returns the cartesian product of elements in the given slices.
 func Product2[T any](items ...[]T) chan []T {
 	c := make(chan []T, 1)
 	go product2(items, c, []T{}, 0)
 	return c
 }
 
-// product is a core implementation of Product
+// product2 is a core implementation of [Product2]
 func product2[T any](items [][]T, c chan []T, left []T, pos int) {
 	// iterate over the last array
 	if pos == len(items)-1 {

--- a/slices/slices.go
+++ b/slices/slices.go
@@ -1,6 +1,6 @@
 package slices
 
-// Concat concatenates given slices into a single slice.
+// Concat concatenates the given slices into a single slice.
 func Concat[S ~[]T, T any](slices ...S) S {
 	size := 0
 	for _, items := range slices {


### PR DESCRIPTION
This is my attempt to improve the godoc for the `slices` package. I have been pretty heavy-handed in some places so I've tried to split the PR up into useful commits.

The general thrust of it is to try to improve spelling, grammar, consistency and readability. It started as just a fix to the spelling in `SortBy`, then I noticed an inconsistent use of `arr`, `items` and `the given slice` to refer to the (primary) slice for each function. 

- `arr` clearly does not match any of the argument names, and may mislead the user into thinking they are modifying the backing array.
- `the given slice` only makes sense when there is one input slice, and is a bit more wordy than the other two options.
- `items` is the correct parameter name and is unambiguous when there are multiple slices, but it reads strangely in some places.

I ended up settling for using `items` almost everywhere, although for me it was a bit of a coin toss which way was better.

Some other consistency changes:
- [always finish godoc with a period](https://gist.github.com/adamveld12/c0d9f0d5f0e1fba1e551#comment-sentences)
- `code blocks` in paragraphs do not get rendered as godoc e.g. [see here](https://pkg.go.dev/github.com/life4/genesis/slices#MapFilter), and this was inconsistently sprinkled into some function docs. I opted to remove this, although it might be clearer to lean into this even if it isn't rendered as it would help with clarity in some cases where the `items` grammar is ambiguous.
- I have added or tweaked the grammar where I think it could be improved (in particular, use of the, a, in, of, ...). In most cases these are minor changes to help with readability.
- Consistent use of `f` rather than `F` to describe function arguments.

For a couple of functions I've taken a stab at rewriting the godoc entirely to make it clearer. I think this helps a lot in cases like `Reject` where you had to go and look at the docs for `Filter` to get a complete picture of what the function was doing, and even more so for `Scan` where the docs were explaining only how it is different from `Reduce`, which is itself a difficult to explain operation.
