### PR TITLE
Fix new golangci-lint violations

### DIFF
--- a/channels/channel_ctx.go
+++ b/channels/channel_ctx.go
@@ -612,6 +612,7 @@ func WithContext[T any](c <-chan T, ctx context.Context) chan T {
 				select {
 				case result <- val:
 				case <-ctx.Done():
+					return
 				}
 			}
 		}

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -2,6 +2,7 @@ package maps_test
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/life4/genesis/maps"
@@ -77,7 +78,7 @@ func TestMap(t *testing.T) {
 	is := is.New(t)
 	m := map[int32]int64{1: 2, 3: 4, 5: 6}
 	f := func(k int32, v int64) (int, string) {
-		return int(k + 1), fmt.Sprintf("%d", v)
+		return int(k + 1), strconv.FormatInt(v, 10)
 	}
 	is.Equal(maps.Map(m, f), map[int]string{2: "2", 4: "4", 6: "6"})
 }

--- a/slices/examples_test.go
+++ b/slices/examples_test.go
@@ -3,6 +3,7 @@ package slices_test
 import (
 	"errors"
 	"fmt"
+	"strconv"
 
 	"github.com/life4/genesis/channels"
 	"github.com/life4/genesis/slices"
@@ -390,7 +391,7 @@ func ExampleMapFilter() {
 	s := []int{4, 8, 15, 16, 23, 42}
 	isEven := func(t int) (string, bool) {
 		if t%2 == 0 {
-			s := fmt.Sprintf("%d", t)
+			s := strconv.Itoa(t)
 			return s, true
 		} else {
 			return "", false

--- a/slices/slice_func_test.go
+++ b/slices/slice_func_test.go
@@ -2,7 +2,7 @@ package slices_test
 
 import (
 	"errors"
-	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/life4/genesis/slices"
@@ -278,7 +278,7 @@ func TestMapFilter(t *testing.T) {
 	f := func(given []int, expected []string) {
 		isEven := func(t int) (string, bool) {
 			if t%2 == 0 {
-				s := fmt.Sprintf("%d", t)
+				s := strconv.Itoa(t)
 				return s, true
 			} else {
 				return "", false


### PR DESCRIPTION
1. Use strconv instead of fmt in some tests.
2. Return faster from WithContext.