### PR TITLE
Remove comparable constraint from DedupBy

### DIFF
--- a/slices/slice_func.go
+++ b/slices/slice_func.go
@@ -65,7 +65,7 @@ func CountBy[S ~[]T, T any](items S, f func(el T) bool) int {
 
 // DedupBy returns a copy of items, but without consecutive elements
 // for which f returns the same result.
-func DedupBy[S ~[]T, T comparable, G comparable](items S, f func(el T) G) S {
+func DedupBy[S ~[]T, T any, G comparable](items S, f func(el T) G) S {
 	result := make(S, 0, len(items))
 	if len(items) == 0 {
 		return result

--- a/slices/slice_func_test.go
+++ b/slices/slice_func_test.go
@@ -78,6 +78,15 @@ func TestDedupBy(t *testing.T) {
 	f([]int{1, 2, 3}, []int{1, 2, 3})
 	f([]int{1, 2, 2, 3}, []int{1, 2, 3})
 	f([]int{1, 2, 4, 3, 5, 7, 10}, []int{1, 2, 3, 10})
+
+	// DedupBy supports non-comparable types.
+	g := func(given [][]int, expected [][]int) {
+		first := func(s []int) int { return s[0] }
+		actual := slices.DedupBy(given, first)
+		is.Equal(actual, expected)
+	}
+	g([][]int{{1}, {1}}, [][]int{{1}})
+	g([][]int{{1}, {1, 2}}, [][]int{{1}})
 }
 
 func TestDropWhile(t *testing.T) {


### PR DESCRIPTION
I couldn't see any reason for DedupBy to require elements in the slice to be comparable, since the comparison is done by the function.

This change relaxes the `comparable` constraint and adds a test case to prove that non-comparable types can be deduped.

The test case is a bit silly, but it's easy to imagine wanting to dedup structs with slices in them and needing this (which is
what I needed).